### PR TITLE
Fix minor bug with current @wired pageRef when using lightning console.

### DIFF
--- a/force-app/main/default/aura/EventServiceBroker/EventServiceBroker.cmp
+++ b/force-app/main/default/aura/EventServiceBroker/EventServiceBroker.cmp
@@ -4,7 +4,10 @@
     <c:EventService aura:id="eventService" recordEventScope="{! v.recordId }"/>
 
     <!-- LWC to Aura -->
-    <c:eventBrokerHandler onmessage="{! c.handleLwcToAuraEvent }"></c:eventBrokerHandler>
+    <c:eventBrokerHandler
+      scopedId="{! v.recordId }"
+      onmessage="{! c.handleLwcToAuraEvent }"
+    ></c:eventBrokerHandler>
 
     <!-- Used only for refreshView right now. If aura initiates one, then it should also go to LWC & vice versa -->
     <aura:attribute name="allowRecursion" type="Boolean" default="true"/>
@@ -13,6 +16,8 @@
     <aura:handler event="force:refreshView" action="{! c.handleForceRefreshViewForLWC }"/>
     <aura:handler event="c:ServiceRecordEvent" action="{! c.handleRecordEventToLWC }"/> <!-- MUST DECLARE WHICH APP EVENTS TO LISTEN TO -->
     <aura:handler event="c:ServiceAppEvent" action="{! c.handleAppEventToLWC }"/> <!-- MUST DECLARE WHICH APP EVENTS TO LISTEN TO -->
-    <c:eventBroker aura:id="eventBroker"></c:eventBroker>
+    <c:eventBroker aura:id="eventBroker"
+      scopedId="{! v.recordId }"
+    ></c:eventBroker>
 
 </aura:component>	

--- a/force-app/main/default/aura/MessageServiceBroker/MessageServiceBroker.cmp
+++ b/force-app/main/default/aura/MessageServiceBroker/MessageServiceBroker.cmp
@@ -1,10 +1,11 @@
-<aura:component implements="flexipage:availableForAllPageTypes">
+<aura:component implements="flexipage:availableForAllPageTypes,force:hasRecordId">
 
     <!-- Service Component boilerplate -->
     <c:MessageService aura:id="messageService"/>
     
     <!-- LWC to Aura -->
     <c:messageBrokerHandler
+      scopedId="{! v.recordId }"
       onmessage="{! c.handleMessageService }"
       onnotifyclose="{! c.handleNotifyClose }"
     ></c:messageBrokerHandler>

--- a/force-app/main/default/lwc/eventBroker/eventBroker.js
+++ b/force-app/main/default/lwc/eventBroker/eventBroker.js
@@ -3,6 +3,7 @@ import { CurrentPageReference } from 'lightning/navigation';
 import { fireEvent } from 'c/pubsub';
 
 export default class EventBroker extends LightningElement {
+  @api scopedId;
   @wire(CurrentPageReference) pageRef;
 
   /* Utilities */
@@ -23,7 +24,7 @@ export default class EventBroker extends LightningElement {
     const finalPayload = {
       type: 'refreshView'
     }
-    this._brokerMessageToAura(finalPayload);
+    this._brokerEventToAura(finalPayload);
   }
   @api
   fireAppEvent(payload) {
@@ -32,7 +33,7 @@ export default class EventBroker extends LightningElement {
       key: payload.key,
       value: payload.value
     }
-    this._brokerMessageToAura(finalPayload);
+    this._brokerEventToAura(finalPayload);
   }
   @api
   fireRecordEvent(payload) {
@@ -42,12 +43,12 @@ export default class EventBroker extends LightningElement {
       value: payload.value,
       recordId: payload.recordId // if provided, overrides recordId on GC_MessageBrokerHandler_LwcWrapper
     }
-    this._brokerMessageToAura(finalPayload);
+    this._brokerEventToAura(finalPayload);
   }
 
   // PRIVATE
-  _brokerMessageToAura(finalPayload) {
-    //console.log(JSON.parse(JSON.stringify(finalPayload)));
-    fireEvent(this.pageRef, 'brokerMessageToAuraEventService', finalPayload);
+  _brokerEventToAura(finalPayload) {
+    const boundary = { scopedId: this.scopedId };
+    fireEvent(this.pageRef, 'brokerEventToAuraEventService', { ...finalPayload, ...boundary } );
   }
 }

--- a/force-app/main/default/lwc/lwcContactAddressForm/lwcContactAddressForm.html
+++ b/force-app/main/default/lwc/lwcContactAddressForm/lwcContactAddressForm.html
@@ -1,4 +1,7 @@
 <template>
+  <!-- Service components -->
+  <c-message-broker scoped-id={scopedId}></c-message-broker>
+
   <template if:true={contact}>
     <lightning-record-edit-form 
       record-id={contact.Id} 

--- a/force-app/main/default/lwc/lwcContactAddressForm/lwcContactAddressForm.js
+++ b/force-app/main/default/lwc/lwcContactAddressForm/lwcContactAddressForm.js
@@ -5,6 +5,7 @@ import { fireEvent } from 'c/pubsub';
 export default class LwcContactAddressForm extends LightningElement {
   @api contact;
   @api pageRef;
+  @api scopedId;
 
   handleSuccess() {
     this.dispatchEvent(new ShowToastEvent({
@@ -12,7 +13,7 @@ export default class LwcContactAddressForm extends LightningElement {
       message: 'Updated Mailing Address Successfully.',
       variant: 'success'
     }));
-    fireEvent(this.pageRef, 'forceRefreshView');
-    fireEvent(this.pageRef, 'notifyClose');
+    fireEvent(this.pageRef, 'forceRefreshView'); // actually targets the datatable for the refresh.
+    this.template.querySelector('c-message-broker').notifyClose(); // consistent to use the @api in case implementation changes. do not fire event directly.
   }
 }

--- a/force-app/main/default/lwc/lwcContactDatatable/lwcContactDatatable.html
+++ b/force-app/main/default/lwc/lwcContactDatatable/lwcContactDatatable.html
@@ -1,7 +1,7 @@
 <template>
   <!-- Service components -->
-  <c-event-broker></c-event-broker>
-  <c-message-broker></c-message-broker>
+  <c-event-broker scoped-id={recordId}></c-event-broker>
+  <c-message-broker scoped-id={recordId}></c-message-broker>
 
   <lightning-card title="Contacts">
     <div if:true={contacts.data} class="slds-border_top">

--- a/force-app/main/default/lwc/lwcContactDatatable/lwcContactDatatable.js
+++ b/force-app/main/default/lwc/lwcContactDatatable/lwcContactDatatable.js
@@ -24,10 +24,11 @@ const TABLE_COLUMNS = [
 export default class LwcContactDatatable extends LightningElement {
   @api
   get recordId() {
-    return this._accountId;
+    return this._recordId;
   }
   set recordId(value) {
     this._accountId = value;
+    this._recordId = value;
   }
   @track columns = TABLE_COLUMNS;
 
@@ -37,7 +38,8 @@ export default class LwcContactDatatable extends LightningElement {
   contacts;
 
   // private
-  _accountId;
+  _accountId; // app flexipages
+  _recordId;  // record flexipage
 
   connectedCallback() {
     registerListener('accountSelected', this.handleAccountSelected, this);
@@ -74,7 +76,8 @@ export default class LwcContactDatatable extends LightningElement {
             component: 'c:lwcContactAddressForm',
             componentParams: {
               contact: row,
-              pageRef: this.pageRef
+              pageRef: this.pageRef,
+              scopedId: this._recordId // null for app page is fine
             }
           }
         }
@@ -111,7 +114,6 @@ export default class LwcContactDatatable extends LightningElement {
   }
 
   async reloadTable() {
-    console.log('reloadTable');
     try {
       this.contacts.data = await getContactsByAccountId({accountId: this._accountId});
     } catch (error) {

--- a/force-app/main/default/lwc/messageBroker/messageBroker.js
+++ b/force-app/main/default/lwc/messageBroker/messageBroker.js
@@ -3,13 +3,14 @@ import { CurrentPageReference } from 'lightning/navigation';
 import { fireEvent } from 'c/pubsub';
 
 export default class MessageBroker extends LightningElement {
+  @api scopedId;
   @wire(CurrentPageReference) pageRef;
 
   /* LWC broker to Aura */
   @api
   messageService(payload) {
-    //console.log(JSON.parse(JSON.stringify(payload)));
-    fireEvent(this.pageRef, 'messageService', payload);
+    const boundary = { scopedId: this.scopedId };
+    fireEvent(this.pageRef, 'messageService', { ...payload, ...boundary } );
   }
 
   @api

--- a/force-app/main/default/lwc/messageBrokerHandler/messageBrokerHandler.js
+++ b/force-app/main/default/lwc/messageBrokerHandler/messageBrokerHandler.js
@@ -1,8 +1,9 @@
-import { LightningElement, wire } from 'lwc';
+import { LightningElement, api, wire } from 'lwc';
 import { CurrentPageReference } from 'lightning/navigation';
 import { registerListener, unregisterAllListeners } from 'c/pubsub';
 
 export default class MessageBrokerHandler extends LightningElement {
+  @api scopedId;
   @wire(CurrentPageReference) pageRef;
 
   connectedCallback() {
@@ -15,8 +16,14 @@ export default class MessageBrokerHandler extends LightningElement {
   }
 
   messageServiceEmitter(payload) {
-    //console.log(JSON.parse(JSON.stringify(payload)));
-    this.dispatchEvent(new CustomEvent('message', { detail: { payload } }));
+    // There seems to be a bug in the pageRef scoping in lightning console app for Spring 19
+    // Will double check again when Summer 19 is GA, after the rounds of post GA hotfix.
+    if (
+      !payload.scopedId                      // for app pages, this is null
+      || payload.scopedId === this.scopedId  // for record flexipages
+    ) {
+      this.dispatchEvent(new CustomEvent('message', { detail: { payload } }));
+    }
   }
 
   notifyCloseEmitter() {


### PR DESCRIPTION
Addendum to the first. In certain situations as follows, it seems @wire pageRef loses proper scoping. The following conditions need to be met:

- Lighting Console used.
- Multiple Record Flexipages of same SObject open (2+).
- `EventServiceBroker.cmp` or `MessageServiceBroker.cmp` (which both have child LWCs) is placed at bottom of the Record Flexipage(s).
- Child LWCs (messageBrokerHandler.js) implement @wire pageRef as a child.
- Wait an extended amount of time with multiple Record Flexipages open.

Then without this commit, `messageBroker.js` @api `fireEvent` functions seemingly cross pageRef boundaries set up by the `pubsub` LWC.

Effectively, one button click would create two `lightning:overlayLibrary` modals when multiple Record Flexipages (remember, each Record Flexipage is embedded with a `MessageServiceBroker.cmp` that's supposedly scoped to register listening of only `this.pageRef`).
