### PR TITLE
Minor enhancements to both collectionDatatable and soqlDatatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,12 +827,12 @@ cd lwc-utils
 
 Option 2 - Installation URL:
 
-[Summer 20 Sandbox / Dev Org](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tB0000000QISdIAO)
+[Summer 20 Sandbox / Dev Org](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tB0000000QISxIAO)
 
 Option 3 - Unlocked Package:
 
 ```
-sfdx force:package:install --package "LWC Utils with Examples@0.1.0-10"
+sfdx force:package:install --package "LWC Utils with Examples@0.1.0-11"
 ```
 
 <!--

--- a/force-app/main/default/classes/DataTableService.cls
+++ b/force-app/main/default/classes/DataTableService.cls
@@ -77,6 +77,9 @@ public inherited sharing class DataTableService {
     private static final String DATATABLE_ACTION_CONFIG_TYPE = 'Actions';
     private static final String DATATABLE_LOOKUP_CONFIG_TYPE = 'Lookups';
 
+    // TODO move to custom metadata config later for performance tuning
+    private static final Integer ROW_LIMITER = 500;
+
     @AuraEnabled(cacheable=true)
     public static String getQueryExceptionMessage(String queryString) {
         System.debug(LoggingLevel.INFO, 'getQueryExceptionMessage queryString is: ' + queryString);
@@ -96,6 +99,31 @@ public inherited sharing class DataTableService {
             result.put(String.valueOf(type), DISPLAY_TYPE_TO_DATATABLE_TYPE_MAP.get(type));
         }
         return result;
+    }
+
+    @AuraEnabled(cacheable=true)
+    public static Map<Id, Id> getRecordTypeIdMap(List<Id> recordIds) {
+        Map<Id, Id> recordTypeIdMap = new Map<Id, Id>();
+
+        // Validate
+        Set<String> objectNames = new Set<String>();
+        for (Id recordId : recordIds) {
+            objectNames.add(recordId.getSobjectType().getDescribe().getName());
+        }
+        if (objectNames.size() != 1) {
+            throw new DataTableServiceException('Only one type of SObject is allowed.');
+        }
+
+        // And then check if we need this
+        String objectName = new List<String>(objectNames)[0];
+        Boolean hasRecordTypes = DataTableService.recordTypeIdsForObject(objectName).size() > 1;
+        if (hasRecordTypes) {
+            String queryString = 'SELECT Id, RecordTypeId FROM ' + objectName + ' LIMIT ' + ROW_LIMITER;
+            for (SObject obj : Database.query(queryString)) {
+                recordTypeIdMap.put(obj.Id, (Id) obj.get('RecordTypeId'));
+            }
+        }
+        return recordTypeIdMap;
     }
 
     @AuraEnabled(cacheable=true)
@@ -138,7 +166,7 @@ public inherited sharing class DataTableService {
     @AuraEnabled
     public static Map<String, Object> getTableCache(Map<String, Object> tableRequest) {
         if (!tableRequest.containsKey(QUERY_STRING_KEY)) {
-            throw new AuraHandledException('Missing Query.');
+            throw new DataTableServiceException('Missing Query.');
         }
         // Gather Schema information from incoming query string
         String queryString = (String) tableRequest.get(QUERY_STRING_KEY);
@@ -199,7 +227,12 @@ public inherited sharing class DataTableService {
      * @return             [List of dynamically queried SObjects]
      */
     private static List<SObject> getSObjectDataFromQueryString(String queryString) {
+        // Safety first
         String.escapeSingleQuotes(queryString);
+        // Performance second
+        if (!queryString.containsIgnoreCase(' LIMIT ')) {
+            queryString += ' LIMIT ' + ROW_LIMITER;
+        }
         System.debug(LoggingLevel.INFO, 'getSObjectDataFromQueryString FINAL queryString is: ' + queryString);
         return Database.query(queryString);
     }
@@ -227,7 +260,7 @@ public inherited sharing class DataTableService {
         try {
             return Database.query(queryString);
         } catch (Exception e) {
-            throw new AuraHandledException(e.getMessage());
+            throw new DataTableServiceException(e.getMessage());
         }
     }
 
@@ -304,7 +337,7 @@ public inherited sharing class DataTableService {
             String columnType = String.valueOf(fieldColumn.get('type'));
 
             if (columnType.equalsIgnoreCase('location')) {
-                throw new AuraHandledException(
+                throw new DataTableServiceException(
                     'Geolocation fields must be queried with __Longitude__s and __Latitude__s suffixes.'
                 );
             }
@@ -404,5 +437,8 @@ public inherited sharing class DataTableService {
             }
         }
         return cleanFieldName.replace('__c', '__r') + '.' + nameField.getDescribe().getName();
+    }
+
+    private class DataTableServiceException extends Exception {
     }
 }

--- a/force-app/main/default/lwc/collectionDatatable/collectionDatatable.js
+++ b/force-app/main/default/lwc/collectionDatatable/collectionDatatable.js
@@ -197,6 +197,9 @@ export default class CollectionDatatable extends LightningElement {
 
     _getCleanRow(row) {
         for (let fieldName in row) {
+            if (typeof row[fieldName] === 'object') {
+                continue;
+            }
             if (!this._objectFieldsMap.has(fieldName)) {
                 delete row[fieldName];
             }

--- a/force-app/main/default/lwc/datatable/datatable.js
+++ b/force-app/main/default/lwc/datatable/datatable.js
@@ -591,6 +591,10 @@ export default class Datatable extends LightningElement {
                 // messageService then publishes this to each one when the edit mode is accessed
                 this._lookupConfigDevName = this.lookupConfigDevName || DATATABLE_LOOKUP_CONFIG_DEFAULT;
             }
+            // Never show the auto-queried RecordTypeId
+            if (col.fieldName.toLowerCase() === 'recordtypeid') {
+                continue;
+            }
             finalColumns.push(col);
         }
         if (this.showRowMenuActions) {

--- a/force-app/main/default/lwc/datatableLookupCell/datatableLookupCell.js
+++ b/force-app/main/default/lwc/datatableLookupCell/datatableLookupCell.js
@@ -122,12 +122,14 @@ export default class DatatableLookupCell extends LightningElement {
             const cellConfig = lookupMap.has(this.referenceObjectApiName)
                 ? lookupMap.get(this.referenceObjectApiName)
                 : lookupMap.get('All');
-            // Send these down to the open source component
-            this.configIconName = cellConfig.Icon_Name__c;
-            this.configTitle = cellConfig.Title_Field__c;
-            this.configSubtitle = cellConfig.Subtitle_Field__c;
-            // Configure lookup changes if edit mode is used
-            this._titleField = `${this.referenceObjectApiName}.${this.configTitle}`;
+            if (cellConfig) {
+                // Send these down to the open source component
+                this.configIconName = cellConfig.Icon_Name__c;
+                this.configTitle = cellConfig.Title_Field__c;
+                this.configSubtitle = cellConfig.Subtitle_Field__c;
+                // Configure lookup changes if edit mode is used
+                this._titleField = `${this.referenceObjectApiName}.${this.configTitle}`;
+            }
         }
     }
 

--- a/force-app/main/default/lwc/datatablePicklistCell/datatablePicklistCell.html
+++ b/force-app/main/default/lwc/datatablePicklistCell/datatablePicklistCell.html
@@ -33,6 +33,12 @@
 -->
 
 <template>
+    <!-- prettier-ignore -->
+    <c-message-service 
+        boundary={tableBoundary}
+        onpicklistconfigload={handlePicklistConfigLoad}
+    ></c-message-service>
+
     <c-datatable-editable-cell
         table-boundary={tableBoundary}
         original-value={value}
@@ -46,7 +52,11 @@
         field-api-name={fieldApiName}
         change-event-name="selected"
     >
-        <lightning-formatted-text slot="displayCell" value={value}></lightning-formatted-text>
+        <!-- prettier-ignore -->
+        <lightning-formatted-text
+            slot="displayCell"
+            value={value}
+        ></lightning-formatted-text>
         <c-picklist
             name="picklist-edit"
             slot="editCell"

--- a/force-app/main/default/lwc/datatablePicklistCell/datatablePicklistCell.js
+++ b/force-app/main/default/lwc/datatablePicklistCell/datatablePicklistCell.js
@@ -59,4 +59,18 @@ export default class DatatablePicklistCell extends LightningElement {
     @api objectApiName;
     @api columnName;
     @api fieldApiName;
+
+    // private
+    _picklistRecordTypeId;
+
+    // Event Handlers
+
+    handlePicklistConfigLoad(event) {
+        const payload = event.detail.value;
+        if (payload.recordTypeIdMap) {
+            const rtMap = new Map(Object.entries(payload.recordTypeIdMap));
+            // TODO make recordId always included, when available, to customPicklist datatype. For now, this is OK.
+            this._picklistRecordTypeId = rtMap.get(this.rowKeyValue);
+        }
+    }
 }

--- a/force-app/main/default/lwc/soqlDatatable/soqlDatatable.js
+++ b/force-app/main/default/lwc/soqlDatatable/soqlDatatable.js
@@ -180,7 +180,7 @@ export default class SoqlDatatable extends LightningElement {
         }
     }
 
-    async connectedCallback() {
+    connectedCallback() {
         if (!this.queryString) {
             return;
         }

--- a/force-app/main/default/lwc/soqlDatatable/soqlDatatable.js
+++ b/force-app/main/default/lwc/soqlDatatable/soqlDatatable.js
@@ -172,6 +172,10 @@ export default class SoqlDatatable extends LightningElement {
     async refreshTable() {
         const cache = await this.fetchTableCache();
         if (cache) {
+            // Currently on App flexipage or $CurrentRecord API not enabled
+            if (!this._objectApiName) {
+                this._objectApiName = cache.objectApiName;
+            }
             this.initializeTable(cache);
         }
     }
@@ -211,11 +215,12 @@ export default class SoqlDatatable extends LightningElement {
                     };
                     this._mergeMap.set(original, config);
                 });
+                // Allow LDS to finish field merging queryString, starting with objectInfo
+                // Unfortunately since we can't control order of wires, we fake it with assignment of vars
+                this._objectApiName = this.objectApiName;
                 return;
             }
         }
-        // Delay getObjectInfo wire until dependencies were set
-        this._objectApiName = this.objectApiName;
         this._finalQueryString = this.queryString;
         this.validateQueryStringAndInitialize();
     }
@@ -272,6 +277,9 @@ export default class SoqlDatatable extends LightningElement {
 
     _getCleanRow(row) {
         for (let fieldName in row) {
+            if (typeof row[fieldName] === 'object') {
+                continue;
+            }
             if (!this._objectFieldsMap.has(fieldName)) {
                 delete row[fieldName];
             }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -21,6 +21,7 @@
         "LWC Utils with Examples@0.1.0-7": "04tB0000000QGbuIAG",
         "LWC Utils with Examples@0.1.0-8": "04tB0000000QH04IAG",
         "LWC Utils with Examples@0.1.0-9": "04tB0000000QHgYIAW",
-        "LWC Utils with Examples@0.1.0-10": "04tB0000000QISdIAO"
+        "LWC Utils with Examples@0.1.0-10": "04tB0000000QISdIAO",
+        "LWC Utils with Examples@0.1.0-11": "04tB0000000QISxIAO"
     }
 }


### PR DESCRIPTION
- Better support for inline editing picklist data types in general.
- Better support for recordTypeId gated values in picklists.
- Add automatic 500 row limit (temporary) for `soqlDatatable`, unless you specify one of your own.
- `soqlDatatable` selected row outputs have been sanitized.
