### PR TITLE
Inline edit picklist and formula link handling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,12 +827,12 @@ cd lwc-utils
 
 Option 2 - Installation URL:
 
-[Summer 20 Sandbox / Dev Org](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tB0000000QISxIAO)
+[Summer 20 Sandbox / Dev Org](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tB0000000QJlAIAW)
 
 Option 3 - Unlocked Package:
 
 ```
-sfdx force:package:install --package "LWC Utils with Examples@0.1.0-11"
+sfdx force:package:install --package "LWC Utils with Examples@0.1.0-12"
 ```
 
 <!--

--- a/force-app/main/default/classes/DataTableService.cls
+++ b/force-app/main/default/classes/DataTableService.cls
@@ -336,6 +336,17 @@ public inherited sharing class DataTableService {
             // Some native data types need some default typeAttributes
             String columnType = String.valueOf(fieldColumn.get('type'));
 
+            // Formula fields may output text links via the HYPERLINK formula
+            if (field.isCalculated() && columnType.equalsIgnoreCase('text')) {
+                String formulaValue = field.getCalculatedFormula();
+                if (String.isNotBlank(formulaValue) && formulaValue.containsIgnoreCase('hyperlink')) {
+                    fieldColumn.put('type', 'customFormula');
+                    Map<String, Object> typeAttributes = getTypeAttributes(fieldColumn);
+                    typeAttributes.put('hyperlinked', true);
+                    fieldColumn.put('typeAttributes', typeAttributes);
+                }
+            }
+
             if (columnType.equalsIgnoreCase('location')) {
                 throw new DataTableServiceException(
                     'Geolocation fields must be queried with __Longitude__s and __Latitude__s suffixes.'

--- a/force-app/main/default/lwc/datatable/datatable.js
+++ b/force-app/main/default/lwc/datatable/datatable.js
@@ -67,10 +67,6 @@ export default class Datatable extends LightningElement {
     // MessageService boundary, for when multiple instances are on same page
     @api uniqueBoundary;
 
-    // SOQL
-    @api queryString;
-    @api isRecordBind = false;
-
     // Misc
     @api columnWidthsMode = 'auto'; // override salesforce default
     @api showRefreshButton = false;

--- a/force-app/main/default/lwc/datatableEditableCell/datatableEditableCell.html
+++ b/force-app/main/default/lwc/datatableEditableCell/datatableEditableCell.html
@@ -65,7 +65,7 @@
                         <template if:true={showMassEdit}>
                             <lightning-layout-item size="12">
                                 <lightning-input
-                                    class="mass-input-checkbox slds-p-bottom_xx-small"
+                                    class="mass-input-checkbox slds-p-around_xx-small"
                                     type="checkbox"
                                     label={checkboxLabel}
                                 ></lightning-input>

--- a/force-app/main/default/lwc/datatableExtension/customFormula.html
+++ b/force-app/main/default/lwc/datatableExtension/customFormula.html
@@ -1,0 +1,46 @@
+<!--
+/**
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2020, james@sparkworks.io
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+-->
+
+<template>
+    <c-datatable-formula-cell
+        is-hyperlink={typeAttributes.hyperlinked}
+        value={value}
+        table-boundary={typeAttributes.tableBoundary}
+        row-key-attribute={typeAttributes.rowKeyAttribute}
+        row-key-value={typeAttributes.rowKeyValue}
+        object-api-name={typeAttributes.objectApiName}
+        column-name={typeAttributes.columnName}
+        field-api-name={typeAttributes.fieldApiName}
+    ></c-datatable-formula-cell>
+</template>

--- a/force-app/main/default/lwc/datatableExtension/datatableExtension.js
+++ b/force-app/main/default/lwc/datatableExtension/datatableExtension.js
@@ -36,6 +36,7 @@ import LightningDatatable from 'lightning/datatable';
 import customName from './customName.html';
 import customPicklist from './customPicklist.html';
 import customLookup from './customLookup.html';
+import customFormula from './customFormula.html';
 
 export default class datatableExtension extends LightningDatatable {
     static customTypes = {
@@ -45,7 +46,7 @@ export default class datatableExtension extends LightningDatatable {
                 // LWC specific attributes
                 'href',
                 'target',
-                // Defaults for datatable-edit-cell
+                // Defaults
                 'tableBoundary',
                 'rowKeyAttribute',
                 'rowKeyValue',
@@ -63,7 +64,7 @@ export default class datatableExtension extends LightningDatatable {
                 // After a lot of random debugging, it appears that recordTypeId is a reserved typeAttribute
                 // which is not passed down correctly if used, so the workaround is to use something more custom
                 'picklistRecordTypeId',
-                // Defaults for datatable-edit-cell
+                // Defaults
                 'tableBoundary',
                 'rowKeyAttribute',
                 'rowKeyValue',
@@ -81,11 +82,25 @@ export default class datatableExtension extends LightningDatatable {
                 'target',
                 'displayValue',
                 'referenceObjectApiName',
-                // Defaults for datatable-edit-cell
+                // Defaults
                 'tableBoundary',
                 'rowKeyAttribute',
                 'rowKeyValue',
                 'isEditable',
+                'objectApiName',
+                'columnName',
+                'fieldApiName'
+            ]
+        },
+        customFormula: {
+            template: customFormula,
+            typeAttributes: [
+                // LWC specific attributes
+                'hyperlinked',
+                // Defaults
+                'tableBoundary',
+                'rowKeyAttribute',
+                'rowKeyValue',
                 'objectApiName',
                 'columnName',
                 'fieldApiName'

--- a/force-app/main/default/lwc/datatableFormulaCell/datatableFormulaCell.html
+++ b/force-app/main/default/lwc/datatableFormulaCell/datatableFormulaCell.html
@@ -1,0 +1,41 @@
+<!--
+/**
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2020, james@sparkworks.io
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+-->
+
+<template>
+    <template if:true={isHyperlink}>
+        <div class="container" lwc:dom="manual">
+            <!-- inject html here -->
+        </div>
+    </template>
+</template>

--- a/force-app/main/default/lwc/datatableFormulaCell/datatableFormulaCell.js
+++ b/force-app/main/default/lwc/datatableFormulaCell/datatableFormulaCell.js
@@ -1,0 +1,62 @@
+/**
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2020, james@sparkworks.io
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { LightningElement, api } from 'lwc';
+
+export default class DatatableFormulaCell extends LightningElement {
+    // LWC specific
+    @api isHyperlink;
+
+    // Defaults for custom data type
+    @api value; // comes in from datatable as the value of the name field
+    @api tableBoundary;
+    @api rowKeyAttribute;
+    @api rowKeyValue;
+    @api objectApiName;
+    @api columnName;
+    @api fieldApiName;
+
+    // private
+    _isRendered;
+
+    renderedCallback() {
+        if (this._isRendered) {
+            return;
+        }
+        this._isRendered = true;
+        const container = this.template.querySelector('.container');
+
+        if (this.isHyperlink && this.value) {
+            container.innerHTML = this.value;
+        }
+    }
+}

--- a/force-app/main/default/lwc/datatableFormulaCell/datatableFormulaCell.js-meta.xml
+++ b/force-app/main/default/lwc/datatableFormulaCell/datatableFormulaCell.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/picklist/picklist.html
+++ b/force-app/main/default/lwc/picklist/picklist.html
@@ -38,5 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         disabled={disabled}
         variant={variant}
         onchange={handleChange}
+        dropdown-alignment="auto"
     ></lightning-combobox>
 </template>

--- a/force-app/main/default/lwc/soqlDatatable/soqlDatatable.html
+++ b/force-app/main/default/lwc/soqlDatatable/soqlDatatable.html
@@ -37,15 +37,13 @@
 
     <c-datatable
         unique-boundary={uniqueBoundary}
+        is-save-to-server
         key-field="Id"
         title={title}
         record-id={recordId}
-        is-record-bind={isRecordBind}
         show-record-count={showRecordCount}
         show-refresh-button={showRefreshButton}
-        query-string={queryString}
         checkbox-type={checkboxType}
-        is-save-to-server
         editable-fields={editableFields}
         sortable-fields={sortableFields}
         sorted-by={sortedBy}

--- a/force-app/main/default/lwc/tableServiceUtils/tableServiceUtils.js
+++ b/force-app/main/default/lwc/tableServiceUtils/tableServiceUtils.js
@@ -105,7 +105,7 @@ const createDataTableError = (datatableErrorRows, recordIdToRowNumberMap) => {
     for (let [key, value] of errorMap.entries()) {
         value.rowNumber = recordIdToRowNumberMap.get(key);
         value.messages.forEach(msg => {
-            tableMessages.push(`Row ${value.rowNumber} ${msg}`);
+            tableMessages.push(`Row ${value.rowNumber}: ${msg}`);
         });
     }
     return {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -22,6 +22,7 @@
         "LWC Utils with Examples@0.1.0-8": "04tB0000000QH04IAG",
         "LWC Utils with Examples@0.1.0-9": "04tB0000000QHgYIAW",
         "LWC Utils with Examples@0.1.0-10": "04tB0000000QISdIAO",
-        "LWC Utils with Examples@0.1.0-11": "04tB0000000QISxIAO"
+        "LWC Utils with Examples@0.1.0-11": "04tB0000000QISxIAO",
+        "LWC Utils with Examples@0.1.0-12": "04tB0000000QJlAIAW"
     }
 }


### PR DESCRIPTION
- During inline edit for picklists, options will no longer be hidden when editing rows at bottom of `soqlDatatable` or `collectionDatatable`.
- Formula fields using a HYPERLINK formula will be given the `customFormula` datatype which processes the link.