### PR TITLE
fix: send the search payload to the lookupService if the input is two characters

### DIFF
--- a/utils-core/main/default/lwc/lookup/lookup.js
+++ b/utils-core/main/default/lwc/lookup/lookup.js
@@ -170,7 +170,7 @@ export default class Lookup extends LightningElement {
         if (ACTIONABLE_KEYS.includes(event.code)) {
             keyAction[event.code]();
         } else {
-            if (this.inputValue.length > 2) {
+            if (this.inputValue.length >= 2) {
                 this.debounceSearch();
             } else if (this.inputValue.length === 0) {
                 this.records = [];


### PR DESCRIPTION
The error says "Minimum 2 characters" but it currently checks `length > 2` instead of `length >= 2`

This allows us to search entities beginning with ISO country codes (fr, gb, etc.)