### PR TITLE
Bugfixes and enhancements

### DIFF
--- a/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.html
+++ b/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.html
@@ -42,6 +42,7 @@
         show-record-count={showRecordCount}
         checkbox-type={checkboxType}
         column-labels={columnLabels}
+        custom-height={customHeight}
         editable-fields={editableFields}
         sortable-fields={sortableFields}
         sorted-by={sortedBy}

--- a/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.html
+++ b/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.html
@@ -44,10 +44,10 @@
         column-labels={columnLabels}
         custom-height={customHeight}
         editable-fields={editableFields}
+        use-load-style-hack-for-overflow={useLoadStyleHackForOverflow}
         sortable-fields={sortableFields}
         sorted-by={sortedBy}
         sorted-direction={sortedDirection}
-        column-widths-mode={columnWidthsMode}
         onsave={handleSave}
         onrowselection={handleRowSelection}
     ></c-datatable>

--- a/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js
+++ b/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js
@@ -65,6 +65,7 @@ export default class CollectionDatatable extends LightningElement {
     @api sortableFields;
     @api sortedBy;
     @api sortedDirection;
+    @api customHeight;
 
     columnWidthsMode = 'auto';
 

--- a/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js
+++ b/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js
@@ -67,13 +67,15 @@ export default class CollectionDatatable extends LightningElement {
     @api sortedDirection;
     @api customHeight;
 
-    columnWidthsMode = 'auto';
-
     // Flow outputs
     @api selectedRows;
     @api firstSelectedRow;
     @api editedRows;
     @api allRows;
+
+    // LWC loadStyle hack - to help with picklist and lookup menu overflows
+    // https://salesforce.stackexchange.com/questions/246887/target-inner-elements-of-standard-lightning-web-components-with-css/252852#252852
+    @api useLoadStyleHackForOverflow;
 
     // private
     _isRendered;

--- a/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js-meta.xml
+++ b/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js-meta.xml
@@ -21,6 +21,7 @@
       <property name="sortedBy" label="Default Sort Field" type="String" description="Single Field API Name. Parent relationship is supported (e.g. Account.Type)." role="inputOnly"/>
       <property name="sortedDirection" label="Default Sort Direction" type="String" default="asc" description="asc or desc" role="inputOnly"/>
       <property name="customHeight" label="Table Height (px)" type="String" description="Sets a table height in pixels. Leave blank for default." role="inputOnly"/>
+      <property name="useLoadStyleHackForOverflow" label=".Allow Overflow (EXPERIMENTAL)" type="Boolean" description="WARNING: Removes scrolling within datatable, only use for small number of rows. Enable this for a small number of rows that require in-line edit. This overrides any custom table heights and allow for picklist and lookup edit menus to display on top of th edatatable. However, you may experience some weird CSS issues."/>
       <!-- OUTPUTS -->
       <property name="selectedRows" label="Selected Rows" type="{sObj[]}" role="outputOnly"/>
       <property name="firstSelectedRow" label="First Selected Row" type="{sObj}" role="outputOnly"/>

--- a/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js-meta.xml
+++ b/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js-meta.xml
@@ -20,6 +20,7 @@
       <property name="sortableFields" label="Sortable Fields" type="String" description="Comma separated list of Field API names. Parent relationship is supported (e.g. Account.Type)." role="inputOnly"/>
       <property name="sortedBy" label="Default Sort Field" type="String" description="Single Field API Name. Parent relationship is supported (e.g. Account.Type)." role="inputOnly"/>
       <property name="sortedDirection" label="Default Sort Direction" type="String" default="asc" description="asc or desc" role="inputOnly"/>
+      <property name="customHeight" label="Table Height (px)" type="String" description="Sets a table height in pixels. Leave blank for default." role="inputOnly"/>
       <!-- OUTPUTS -->
       <property name="selectedRows" label="Selected Rows" type="{sObj[]}" role="outputOnly"/>
       <property name="firstSelectedRow" label="First Selected Row" type="{sObj}" role="outputOnly"/>

--- a/utils-core/main/default/lwc/datatable/datatable.html
+++ b/utils-core/main/default/lwc/datatable/datatable.html
@@ -42,7 +42,7 @@
                 <template if:false={showRecordCount}> {title} </template>
             </slot>
         </div>
-        <div class={containerClass} style={customRelativeHeight}>
+        <div class={containerClass} style={customHeightStyle}>
             <template if:true={showSpinner}>
                 <lightning-spinner alternative-text="Loading"></lightning-spinner>
             </template>

--- a/utils-core/main/default/lwc/datatable/datatable.js
+++ b/utils-core/main/default/lwc/datatable/datatable.js
@@ -72,8 +72,9 @@ export default class Datatable extends LightningElement {
     @api columnWidthsMode = 'auto'; // override salesforce default
     @api showRefreshButton = false;
     @api showSpinner = false;
-    @api useRelativeMaxHeight = false;
+    @api customHeight;
     @api customRelativeMaxHeight;
+    @api useRelativeMaxHeight = false;
 
     // Sorting
     @api
@@ -816,18 +817,21 @@ export default class Datatable extends LightningElement {
         return css;
     }
 
+    get customHeightStyle() {
+        if (this.useRelativeMaxHeight && !!this.customRelativeMaxHeight) {
+            return `height: ${this.customRelativeMaxHeight}vh;`;
+        }
+        if (!this.useRelativeMaxHeight && this.customHeight) {
+            return `height: ${this.customHeight}px;`;
+        }
+        return '';
+    }
+
     get refreshClass() {
         let css = 'slds-p-left_x-small ';
         if (!this.showTableActions) {
             css += 'slds-p-right_small ';
         }
         return css;
-    }
-
-    get customRelativeHeight() {
-        if (this.useRelativeMaxHeight && !!this.customRelativeMaxHeight) {
-            return `height: ${this.customRelativeMaxHeight}vh;`;
-        }
-        return '';
     }
 }

--- a/utils-core/main/default/lwc/datatable/datatable.js
+++ b/utils-core/main/default/lwc/datatable/datatable.js
@@ -53,6 +53,11 @@ const ROW_ACTION_CHECK = 'Row Action';
 // Datatable_Lookup_Config__mdt
 const DATATABLE_LOOKUP_CONFIG_DEFAULT = 'Default_Lookup_Config';
 
+// LWC loadStyle hack - to help with picklist and lookup menu overflows
+// https://salesforce.stackexchange.com/questions/246887/target-inner-elements-of-standard-lightning-web-components-with-css/252852#252852
+import datatableLoadStyleHack from '@salesforce/resourceUrl/datatableLoadStyleHack';
+import { loadStyle } from 'lightning/platformResourceLoader';
+
 export default class Datatable extends LightningElement {
     @api recordId;
     @api
@@ -156,6 +161,10 @@ export default class Datatable extends LightningElement {
     // Datatable_Config__mdt configs
     @api actionConfigDevName;
     @api lookupConfigDevName;
+
+    // LWC loadStyle hack - to help with picklist and lookup menu overflows
+    // https://salesforce.stackexchange.com/questions/246887/target-inner-elements-of-standard-lightning-web-components-with-css/252852#252852
+    @api useLoadStyleHackForOverflow;
 
     // Template and getters
     isHideCheckbox = true;
@@ -295,6 +304,10 @@ export default class Datatable extends LightningElement {
         }
         this._isRendered = true;
         this._messageService = this.template.querySelector('c-message-service');
+        // See imports for loadStyle hack
+        if (this.useLoadStyleHackForOverflow) {
+            loadStyle(this, datatableLoadStyleHack + '/scrollable-overflow-visible.css');
+        }
     }
 
     // Event Handlers
@@ -810,19 +823,20 @@ export default class Datatable extends LightningElement {
     // Class expressions
 
     get containerClass() {
-        let css = 'slds-border_top slds-border_bottom slds-border_left slds-border_right slds-is-relative ';
-        if (this.useRelativeMaxHeight) {
-            css += this.customRelativeMaxHeight ? '' : 'table-vh ';
-        }
-        return css;
+        return 'slds-border_top slds-border_bottom slds-border_left slds-border_right slds-is-relative';
     }
 
     get customHeightStyle() {
-        if (this.useRelativeMaxHeight && !!this.customRelativeMaxHeight) {
-            return `height: ${this.customRelativeMaxHeight}vh;`;
+        if (this.useLoadStyleHackForOverflow) {
+            return '';
         }
-        if (!this.useRelativeMaxHeight && this.customHeight) {
+        if (this.customHeight) {
             return `height: ${this.customHeight}px;`;
+        }
+        if (this.useRelativeMaxHeight) {
+            // 62vh tries to take into account both global header and utility bar
+            const viewHeight = this.customRelativeMaxHeight ? this.customRelativeMaxHeight : '62';
+            return `height: ${viewHeight}vh;`;
         }
         return '';
     }

--- a/utils-core/main/default/lwc/datatablePicklistCell/datatablePicklistCell.js
+++ b/utils-core/main/default/lwc/datatablePicklistCell/datatablePicklistCell.js
@@ -85,10 +85,17 @@ export default class DatatablePicklistCell extends LightningElement {
         if (this._isCleared) {
             return null;
         }
-        if (this._valueToLabelMap.size && !this._selectedValue) {
+        if (!this._valueToLabelMap || this._valueToLabelMap.size === 0) {
+            return this.value;
+        }
+        // Supports if database has a value not currently in the picklist options
+        if (!this._valueToLabelMap.has(this.value)) {
+            return this.value;
+        }
+        if (this._valueToLabelMap.has(this.value)) {
             return this._valueToLabelMap.get(this.value);
         }
-        if (this._valueToLabelMap.size && this._selectedValue) {
+        if (this._selectedValue) {
             return this._valueToLabelMap.get(this._selectedValue);
         }
         return this.value;

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.html
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.html
@@ -49,6 +49,7 @@
         custom-relative-max-height={customRelativeMaxHeight}
         use-relative-max-height={useRelativeMaxHeight}
         editable-fields={editableFields}
+        use-load-style-hack-for-overflow={useLoadStyleHackForOverflow}
         sortable-fields={sortableFields}
         sorted-by={sortedBy}
         sorted-direction={sortedDirection}

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.html
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.html
@@ -45,7 +45,9 @@
         show-refresh-button={showRefreshButton}
         checkbox-type={checkboxType}
         column-labels={columnLabels}
+        custom-height={customHeight}
         custom-relative-max-height={customRelativeMaxHeight}
+        use-relative-max-height={useRelativeMaxHeight}
         editable-fields={editableFields}
         sortable-fields={sortableFields}
         sorted-by={sortedBy}
@@ -55,6 +57,5 @@
         show-spinner={showSpinner}
         action-config-dev-name={actionConfigDevName}
         lookup-config-dev-name={lookupConfigDevName}
-        use-relative-max-height={useRelativeMaxHeight}
     ></c-datatable>
 </template>

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
@@ -85,8 +85,10 @@ export default class SoqlDatatable extends LightningElement {
     @api sortableFields;
     @api sortedBy;
     @api sortedDirection = 'asc';
-    @api useRelativeMaxHeight = false;
+
+    @api customHeight;
     @api customRelativeMaxHeight;
+    @api useRelativeMaxHeight = false;
 
     // Table and Row Actions
     @api actionConfigDevName;

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
@@ -96,6 +96,10 @@ export default class SoqlDatatable extends LightningElement {
     /// For inline edit lookup search behavior
     @api lookupConfigDevName;
 
+    // LWC loadStyle hack - to help with picklist and lookup menu overflows
+    // https://salesforce.stackexchange.com/questions/246887/target-inner-elements-of-standard-lightning-web-components-with-css/252852#252852
+    @api useLoadStyleHackForOverflow;
+
     // Flow outputs
     @api selectedRows;
     @api firstSelectedRow;

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js-meta.xml
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js-meta.xml
@@ -56,6 +56,7 @@
       <property name="sortableFields" label="Sortable Fields" type="String" description="Comma separated list of Field API names. Parent relationship is supported (e.g. Account.Type)." role="inputOnly"/>
       <property name="sortedBy" label="Default Sort Field" type="String" description="Single Field API Name. Parent relationship is supported (e.g. Account.Type)." role="inputOnly"/>
       <property name="sortedDirection" label="Default Sort Direction" type="String" default="asc" description="asc or desc" role="inputOnly"/>
+      <property name="customHeight" label="Table Height (px)" type="String" description="Leave blank for default." role="inputOnly"/>
       <!-- OUTPUTS -->
       <property name="selectedRows" label="Selected Rows" type="{sObj[]}" role="outputOnly"/>
       <property name="firstSelectedRow" label="First Selected Row" type="{sObj}" role="outputOnly"/>

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js-meta.xml
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js-meta.xml
@@ -24,8 +24,9 @@
       <property name="sortedDirection" label="Default Sort Direction" type="String" datasource="asc,desc" default="asc"/>
       <property name="actionConfigDevName" label="Action Configuration" type="String" description="Configure table and row actions with a record in Datatable_Config__mdt"/>
       <property name="lookupConfigDevName" label="Lookup Configuration" type="String" description="Configure inline edit lookup search behavior with a record in Datatable_Config__mdt"/>
-      <property name="useRelativeMaxHeight" label="Limit Height (Relative to screen)" type="Boolean" description="Force table height to 60% of the vertical screen space. To set a custom percentage, use this in conjunction with customRelativeMaxHeight" default="false"/>
-      <property name="customRelativeMaxHeight" label="Custom Relative Max Height" type="String" description="Set custom max height relative to the vertical screen space. useRelativeMaxHeight must be true for this to work." default=""/>
+      <property name="useRelativeMaxHeight" label="Limit Height (Relative to screen)" type="Boolean" description="Force table height to 60% of the vertical screen space. To set a custom percentage, use this in conjunction with Custom Relative Max Height" default="false"/>
+      <property name="customRelativeMaxHeight" label="Custom Relative Max Height" type="String" description="Set custom max height (0-100) relative to the vertical screen space. Limit Height must first be enabled." default=""/>
+      <property name="useLoadStyleHackForOverflow" label=".Allow Overflow (EXPERIMENTAL)" type="Boolean" description="Enable this when your datatable has a small number of rows but you need in-line edit. This will override any custom table heights and allow for picklist and lookup edit menus to display on top of th edatatable. However, you may experience some weird CSS issues."/>
     </targetConfig>
     <targetConfig targets="lightning__RecordPage">
       <property name="isRecordBind" label="Use Record Binding in SOQL String" type="Boolean" description="Use $CurrentRecord or $recordId in your SOQL query to use record context. User must have FLS access." default="true"/>
@@ -41,8 +42,9 @@
       <property name="sortedDirection" label="Default Sort Direction" type="String" datasource="asc,desc" default="asc"/>
       <property name="actionConfigDevName" label="Action Configuration" type="String" description="Configure table and row actions with a record in Datatable_Config__mdt"/>
       <property name="lookupConfigDevName" label="Lookup Configuration" type="String" description="Configure inline edit lookup search behavior with a record in Datatable_Config__mdt"/>
-      <property name="useRelativeMaxHeight" label="Limit Height (Relative to screen)" type="Boolean" description="Force table height to 60% of the vertical screen space. To set a custom percentage, use this in conjunction with customRelativeMaxHeight" default="false"/>
-      <property name="customRelativeMaxHeight" label="Custom Relative Max Height" type="String" description="Set custom max height relative to the vertical screen space. useRelativeMaxHeight must be true for this to work." default=""/>
+      <property name="useRelativeMaxHeight" label="Limit Height (Relative to screen)" type="Boolean" description="Force table height to 60% of the vertical screen space. To set a custom percentage, use this in conjunction with Custom Relative Max Height" default="false"/>
+      <property name="customRelativeMaxHeight" label="Custom Relative Max Height" type="String" description="Set custom max height (0-100) relative to the vertical screen space. Limit Height must first be enabled." default=""/>
+      <property name="useLoadStyleHackForOverflow" label=".Allow Overflow (EXPERIMENTAL)" type="Boolean" description="Enable this when your datatable has a small number of rows but you need in-line edit. This will override any custom table heights and allow for picklist and lookup edit menus to display on top of th edatatable. However, you may experience some weird CSS issues."/>
     </targetConfig>
     <targetConfig targets="lightning__FlowScreen">
       <propertyType name="sObj" extends="SObject" label="Object"/>
@@ -56,7 +58,8 @@
       <property name="sortableFields" label="Sortable Fields" type="String" description="Comma separated list of Field API names. Parent relationship is supported (e.g. Account.Type)." role="inputOnly"/>
       <property name="sortedBy" label="Default Sort Field" type="String" description="Single Field API Name. Parent relationship is supported (e.g. Account.Type)." role="inputOnly"/>
       <property name="sortedDirection" label="Default Sort Direction" type="String" default="asc" description="asc or desc" role="inputOnly"/>
-      <property name="customHeight" label="Table Height (px)" type="String" description="Leave blank for default." role="inputOnly"/>
+      <property name="customHeight" label="Table Height (px)" type="String" description="Sets a table height in pixels. Leave blank for default." role="inputOnly"/>
+      <property name="useLoadStyleHackForOverflow" label=".Allow Overflow (EXPERIMENTAL)" type="Boolean" description="WARNING: Removes scrolling within datatable, only use for small number of rows. Enable this for a small number of rows that require in-line edit. This overrides any custom table heights and allow for picklist and lookup edit menus to display on top of th edatatable. However, you may experience some weird CSS issues."/>
       <!-- OUTPUTS -->
       <property name="selectedRows" label="Selected Rows" type="{sObj[]}" role="outputOnly"/>
       <property name="firstSelectedRow" label="First Selected Row" type="{sObj}" role="outputOnly"/>

--- a/utils-core/main/default/staticresources/datatableLoadStyleHack.resource-meta.xml
+++ b/utils-core/main/default/staticresources/datatableLoadStyleHack.resource-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <cacheControl>Public</cacheControl>
+    <contentType>application/zip</contentType>
+    <description>Used by datatable to allow for overflow when in-line editing datatable with only a few rows.</description>
+</StaticResource>

--- a/utils-core/main/default/staticresources/datatableLoadStyleHack/scrollable-overflow-visible.css
+++ b/utils-core/main/default/staticresources/datatableLoadStyleHack/scrollable-overflow-visible.css
@@ -1,0 +1,6 @@
+.slds-scrollable_x {
+  overflow: visible !important;
+}
+.slds-scrollable_y {
+  overflow: visible !important;
+}


### PR DESCRIPTION
Fixes #49 

- Adds `customHeight` aka Table Height (px) to both `soql` / `collectionDatatable` for Screen Flows.
    - Screen flows won't support relative vh (view height). 
- Adds the `loadStyle` hack which forces CSS overflow so that in-line edit of picklists can overflow below the datatable container.
    - Use at the risk of minor CSS issues.
    - Should only be used when in-line edit is required for < 5 rows.
- Fixes incorrect display of picklist values when database saved value is not found in the picklist options.