### PR TITLE
Bugfixes and enhancements

### DIFF
--- a/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js
+++ b/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js
@@ -74,7 +74,7 @@ export default class CollectionDatatable extends LightningElement {
     @api allRows;
 
     // LWC loadStyle hack - to help with picklist and lookup menu overflows
-    // https://salesforce.stackexchange.com/questions/246887/target-inner-elements-of-standard-lightning-web-components-with-css/252852#252852
+    // https://salesforce.stackexchange.com/a/270624
     @api useLoadStyleHackForOverflow;
 
     // private

--- a/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js-meta.xml
+++ b/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js-meta.xml
@@ -10,7 +10,7 @@
   <targetConfigs>
     <targetConfig targets="lightning__FlowScreen">
       <propertyType name="sObj" extends="SObject" label="Object"/>
-      <property name="recordCollection" label="Record Collection" type="{sObj[]}"/>
+      <property name="recordCollection" label="Record Collection" type="{sObj[]}" role="inputOnly"/>
       <property name="title" label="Title" type="String" role="inputOnly"/>
       <property name="showRecordCount" label="Show Record Count" type="Boolean" role="inputOnly"/>
       <property name="checkboxType" label="Checkbox Type" type="String" description="None, Multi, or Single" role="inputOnly"/>
@@ -21,7 +21,7 @@
       <property name="sortedBy" label="Default Sort Field" type="String" description="Single Field API Name. Parent relationship is supported (e.g. Account.Type)." role="inputOnly"/>
       <property name="sortedDirection" label="Default Sort Direction" type="String" default="asc" description="asc or desc" role="inputOnly"/>
       <property name="customHeight" label="Table Height (px)" type="String" description="Sets a table height in pixels. Leave blank for default." role="inputOnly"/>
-      <property name="useLoadStyleHackForOverflow" label=".Allow Overflow (EXPERIMENTAL)" type="Boolean" description="WARNING: Removes scrolling within datatable, only use for small number of rows. Enable this for a small number of rows that require in-line edit. This overrides any custom table heights and allow for picklist and lookup edit menus to display on top of th edatatable. However, you may experience some weird CSS issues."/>
+      <property name="useLoadStyleHackForOverflow" label=".Allow Overflow (EXPERIMENTAL)" type="Boolean" description="WARNING: Removes scrolling within datatable, only use for small number of rows. Enable this for a small number of rows that require in-line edit. This overrides any custom table heights and allow for picklist and lookup edit menus to display on top of th edatatable. However, you may experience some weird CSS issues." role="inputOnly">
       <!-- OUTPUTS -->
       <property name="selectedRows" label="Selected Rows" type="{sObj[]}" role="outputOnly"/>
       <property name="firstSelectedRow" label="First Selected Row" type="{sObj}" role="outputOnly"/>

--- a/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js-meta.xml
+++ b/utils-core/main/default/lwc/collectionDatatable/collectionDatatable.js-meta.xml
@@ -21,7 +21,7 @@
       <property name="sortedBy" label="Default Sort Field" type="String" description="Single Field API Name. Parent relationship is supported (e.g. Account.Type)." role="inputOnly"/>
       <property name="sortedDirection" label="Default Sort Direction" type="String" default="asc" description="asc or desc" role="inputOnly"/>
       <property name="customHeight" label="Table Height (px)" type="String" description="Sets a table height in pixels. Leave blank for default." role="inputOnly"/>
-      <property name="useLoadStyleHackForOverflow" label=".Allow Overflow (EXPERIMENTAL)" type="Boolean" description="WARNING: Removes scrolling within datatable, only use for small number of rows. Enable this for a small number of rows that require in-line edit. This overrides any custom table heights and allow for picklist and lookup edit menus to display on top of th edatatable. However, you may experience some weird CSS issues." role="inputOnly">
+      <property name="useLoadStyleHackForOverflow" label=".Allow Overflow (EXPERIMENTAL)" type="Boolean" description="WARNING: Removes scrolling within datatable, only use for small number of rows. Enable this for a small number of rows that require in-line edit. This overrides any custom table heights and allow for picklist and lookup edit menus to display on top of th edatatable. However, you may experience some weird CSS issues." role="inputOnly"/>
       <!-- OUTPUTS -->
       <property name="selectedRows" label="Selected Rows" type="{sObj[]}" role="outputOnly"/>
       <property name="firstSelectedRow" label="First Selected Row" type="{sObj}" role="outputOnly"/>

--- a/utils-core/main/default/lwc/datatable/datatable.html
+++ b/utils-core/main/default/lwc/datatable/datatable.html
@@ -47,6 +47,7 @@
                 <lightning-spinner alternative-text="Loading"></lightning-spinner>
             </template>
             <c-datatable-extension
+                class={extensionBoundaryClass}
                 key-field={keyField}
                 show-row-number-column={isShowRowNumber}
                 hide-checkbox-column={isHideCheckbox}

--- a/utils-core/main/default/lwc/datatable/datatable.js
+++ b/utils-core/main/default/lwc/datatable/datatable.js
@@ -53,11 +53,6 @@ const ROW_ACTION_CHECK = 'Row Action';
 // Datatable_Lookup_Config__mdt
 const DATATABLE_LOOKUP_CONFIG_DEFAULT = 'Default_Lookup_Config';
 
-// LWC loadStyle hack - to help with picklist and lookup menu overflows
-// https://salesforce.stackexchange.com/questions/246887/target-inner-elements-of-standard-lightning-web-components-with-css/252852#252852
-import datatableLoadStyleHack from '@salesforce/resourceUrl/datatableLoadStyleHack';
-import { loadStyle } from 'lightning/platformResourceLoader';
-
 export default class Datatable extends LightningElement {
     @api recordId;
     @api
@@ -163,7 +158,7 @@ export default class Datatable extends LightningElement {
     @api lookupConfigDevName;
 
     // LWC loadStyle hack - to help with picklist and lookup menu overflows
-    // https://salesforce.stackexchange.com/questions/246887/target-inner-elements-of-standard-lightning-web-components-with-css/252852#252852
+    // https://salesforce.stackexchange.com/a/270624
     @api useLoadStyleHackForOverflow;
 
     // Template and getters
@@ -304,9 +299,18 @@ export default class Datatable extends LightningElement {
         }
         this._isRendered = true;
         this._messageService = this.template.querySelector('c-message-service');
-        // See imports for loadStyle hack
+        // Assists with in-line edit on tables with only a few rows
         if (this.useLoadStyleHackForOverflow) {
-            loadStyle(this, datatableLoadStyleHack + '/scrollable-overflow-visible.css');
+            const style = document.createElement('style');
+            style.innerText = `
+                .${this.extensionBoundaryClass} .slds-scrollable_x {
+                  overflow: visible !important;
+                }
+                .${this.extensionBoundaryClass} .slds-scrollable_y {
+                  overflow: visible !important;
+                }
+            `;
+            this.template.querySelector(`.${this.extensionBoundaryClass}`).appendChild(style);
         }
     }
 
@@ -823,7 +827,17 @@ export default class Datatable extends LightningElement {
     // Class expressions
 
     get containerClass() {
-        return 'slds-border_top slds-border_bottom slds-border_left slds-border_right slds-is-relative';
+        return [
+            'slds-border_top',
+            'slds-border_bottom',
+            'slds-border_left',
+            'slds-border_right',
+            'slds-is-relative'
+        ].join(' ');
+    }
+
+    get extensionBoundaryClass() {
+        return `extension-boundary-class-${this.uniqueBoundary}`;
     }
 
     get customHeightStyle() {

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
@@ -97,7 +97,7 @@ export default class SoqlDatatable extends LightningElement {
     @api lookupConfigDevName;
 
     // LWC loadStyle hack - to help with picklist and lookup menu overflows
-    // https://salesforce.stackexchange.com/questions/246887/target-inner-elements-of-standard-lightning-web-components-with-css/252852#252852
+    // https://salesforce.stackexchange.com/a/270624
     @api useLoadStyleHackForOverflow;
 
     // Flow outputs

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js-meta.xml
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js-meta.xml
@@ -59,7 +59,7 @@
       <property name="sortedBy" label="Default Sort Field" type="String" description="Single Field API Name. Parent relationship is supported (e.g. Account.Type)." role="inputOnly"/>
       <property name="sortedDirection" label="Default Sort Direction" type="String" default="asc" description="asc or desc" role="inputOnly"/>
       <property name="customHeight" label="Table Height (px)" type="String" description="Sets a table height in pixels. Leave blank for default." role="inputOnly"/>
-      <property name="useLoadStyleHackForOverflow" label=".Allow Overflow (EXPERIMENTAL)" type="Boolean" description="WARNING: Removes scrolling within datatable, only use for small number of rows. Enable this for a small number of rows that require in-line edit. This overrides any custom table heights and allow for picklist and lookup edit menus to display on top of th edatatable. However, you may experience some weird CSS issues."/>
+      <property name="useLoadStyleHackForOverflow" label=".Allow Overflow (EXPERIMENTAL)" type="Boolean" description="WARNING: Removes scrolling within datatable, only use for small number of rows. Enable this for a small number of rows that require in-line edit. This overrides any custom table heights and allow for picklist and lookup edit menus to display on top of th edatatable. However, you may experience some weird CSS issues." role="inputOnly"/>
       <!-- OUTPUTS -->
       <property name="selectedRows" label="Selected Rows" type="{sObj[]}" role="outputOnly"/>
       <property name="firstSelectedRow" label="First Selected Row" type="{sObj}" role="outputOnly"/>

--- a/utils-core/main/default/staticresources/datatableLoadStyleHack.resource-meta.xml
+++ b/utils-core/main/default/staticresources/datatableLoadStyleHack.resource-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
-    <cacheControl>Public</cacheControl>
-    <contentType>application/zip</contentType>
-    <description>Used by datatable to allow for overflow when in-line editing datatable with only a few rows.</description>
-</StaticResource>

--- a/utils-core/main/default/staticresources/datatableLoadStyleHack/scrollable-overflow-visible.css
+++ b/utils-core/main/default/staticresources/datatableLoadStyleHack/scrollable-overflow-visible.css
@@ -1,6 +1,0 @@
-.slds-scrollable_x {
-  overflow: visible !important;
-}
-.slds-scrollable_y {
-  overflow: visible !important;
-}

--- a/utils-recipes/main/default/flexipages/Collection_Datatable.flexipage-meta.xml
+++ b/utils-recipes/main/default/flexipages/Collection_Datatable.flexipage-meta.xml
@@ -14,6 +14,19 @@
                 <componentName>flowruntime:interview</componentName>
             </componentInstance>
         </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>decorate</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>richTextValue</name>
+                    <value>&lt;p style=&quot;text-align: center;&quot;&gt;The above Collection Datatable is now using the Allow Overflow (EXPERIMENTAL) boolean to allow for in-line edit lookup to overflow outside its container.&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;br&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;This causes some minor CSS issues but is the only way to get interactive in-line edit menus to show up nicely when there are only a few rows!&lt;/p&gt;</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:richText</componentName>
+            </componentInstance>
+        </itemInstances>
         <name>region1</name>
         <type>Region</type>
     </flexiPageRegions>

--- a/utils-recipes/main/default/flows/Collection_Datatable_Manipulate_a_Record_Collection.flow-meta.xml
+++ b/utils-recipes/main/default/flows/Collection_Datatable_Manipulate_a_Record_Collection.flow-meta.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
     <assignments>
         <name>Set_Count</name>
         <label>Set Count</label>
-        <locationX>608</locationX>
-        <locationY>475</locationY>
+        <locationX>547</locationX>
+        <locationY>436</locationY>
         <assignmentItems>
             <assignToReference>EditedRowsCount</assignToReference>
             <operator>AssignCount</operator>
@@ -12,16 +13,75 @@
                 <elementReference>Contacts_Datatable.editedRows</elementReference>
             </value>
         </assignmentItems>
+        <assignmentItems>
+            <assignToReference>EditedRows</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Contacts_Datatable.editedRows</elementReference>
+            </value>
+        </assignmentItems>
         <connector>
-            <targetReference>Confirm</targetReference>
+            <targetReference>Check_Edited_Rows</targetReference>
         </connector>
     </assignments>
+    <decisions>
+        <name>Check_Edited_Rows</name>
+        <label>Check Edited Rows</label>
+        <locationX>538</locationX>
+        <locationY>576</locationY>
+        <defaultConnector>
+            <targetReference>No_Rows_Edited</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>No Edited Rows</defaultConnectorLabel>
+        <rules>
+            <name>Has_Edited_Rows</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>EditedRowsCount</leftValueReference>
+                <operator>GreaterThan</operator>
+                <rightValue>
+                    <numberValue>0.0</numberValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>EditedRows</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Edited_Rows_Loop</targetReference>
+            </connector>
+            <label>Has Edited Rows</label>
+        </rules>
+    </decisions>
     <interviewLabel>Collection Datatable - Manipulate a Record Collection {!$Flow.CurrentDateTime}</interviewLabel>
     <label>Collection Datatable - Manipulate a Record Collection</label>
+    <loops>
+        <name>Edited_Rows_Loop</name>
+        <label>Edited Rows Loop</label>
+        <locationX>766</locationX>
+        <locationY>578</locationY>
+        <collectionReference>EditedRows</collectionReference>
+        <iterationOrder>Asc</iterationOrder>
+        <nextValueConnector>
+            <targetReference>Show_Row_Data</targetReference>
+        </nextValueConnector>
+        <noMoreValuesConnector>
+            <targetReference>Confirm</targetReference>
+        </noMoreValuesConnector>
+    </loops>
     <processMetadataValues>
         <name>BuilderType</name>
         <value>
             <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>FREE_FORM_CANVAS</stringValue>
         </value>
     </processMetadataValues>
     <processMetadataValues>
@@ -43,6 +103,7 @@
         <faultConnector>
             <targetReference>Fault</targetReference>
         </faultConnector>
+        <filterLogic>and</filterLogic>
         <filters>
             <field>FirstName</field>
             <operator>StartsWith</operator>
@@ -59,8 +120,8 @@
     <recordUpdates>
         <name>Update_Edited_Records</name>
         <label>Update Edited Records</label>
-        <locationX>794</locationX>
-        <locationY>305</locationY>
+        <locationX>1001</locationX>
+        <locationY>302</locationY>
         <connector>
             <targetReference>Success</targetReference>
         </connector>
@@ -72,8 +133,8 @@
     <screens>
         <name>Confirm</name>
         <label>Confirm</label>
-        <locationX>667</locationX>
-        <locationY>305</locationY>
+        <locationX>863</locationX>
+        <locationY>302</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -91,8 +152,8 @@
     <screens>
         <name>Fault</name>
         <label>Fault</label>
-        <locationX>607</locationX>
-        <locationY>50</locationY>
+        <locationX>716</locationX>
+        <locationY>24</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -105,10 +166,26 @@
         <showHeader>true</showHeader>
     </screens>
     <screens>
+        <name>No_Rows_Edited</name>
+        <label>No Rows Edited</label>
+        <locationX>347</locationX>
+        <locationY>574</locationY>
+        <allowBack>true</allowBack>
+        <allowFinish>false</allowFinish>
+        <allowPause>false</allowPause>
+        <fields>
+            <name>No_Rows_Edited_Message</name>
+            <fieldText>&lt;p style=&quot;text-align: center;&quot;&gt;No rows edited, please go back and edit rows&lt;/p&gt;</fieldText>
+            <fieldType>DisplayText</fieldType>
+        </fields>
+        <showFooter>true</showFooter>
+        <showHeader>true</showHeader>
+    </screens>
+    <screens>
         <name>Show_Contacts</name>
         <label>Show Contacts</label>
-        <locationX>546</locationX>
-        <locationY>303</locationY>
+        <locationX>548</locationX>
+        <locationY>301</locationY>
         <allowBack>false</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -165,6 +242,12 @@
                     <stringValue>Multi</stringValue>
                 </value>
             </inputParameters>
+            <inputParameters>
+                <name>useLoadStyleHackForOverflow</name>
+                <value>
+                    <booleanValue>true</booleanValue>
+                </value>
+            </inputParameters>
             <isRequired>true</isRequired>
             <storeOutputAutomatically>true</storeOutputAutomatically>
         </fields>
@@ -172,10 +255,29 @@
         <showHeader>true</showHeader>
     </screens>
     <screens>
+        <name>Show_Row_Data</name>
+        <label>Show Row Data</label>
+        <locationX>689</locationX>
+        <locationY>304</locationY>
+        <allowBack>true</allowBack>
+        <allowFinish>true</allowFinish>
+        <allowPause>false</allowPause>
+        <connector>
+            <targetReference>Edited_Rows_Loop</targetReference>
+        </connector>
+        <fields>
+            <name>Row_Data_Screen_Message</name>
+            <fieldText>&lt;p&gt;Below is Account Info for: {!Edited_Rows_Loop.Name}&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;Account Name: {!Edited_Rows_Loop.Account.Name}&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;IMPORTANT&lt;/b&gt;: If using Get Record with automatically grab all fields, parent fields are automatically grabbed for use here.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;Additionally, this will show the currently edited field only. For example, if you change the &lt;span style=&quot;font-family: courier;&quot;&gt;AccountId from in-line edit&lt;/span&gt;, the &lt;span style=&quot;font-family: courier;&quot;&gt;Account.Type &lt;/span&gt;will not change. Be careful when using merge fields for row data in each loop.&lt;/p&gt;</fieldText>
+            <fieldType>DisplayText</fieldType>
+        </fields>
+        <showFooter>true</showFooter>
+        <showHeader>true</showHeader>
+    </screens>
+    <screens>
         <name>Success</name>
         <label>Success</label>
-        <locationX>924</locationX>
-        <locationY>305</locationY>
+        <locationX>1112</locationX>
+        <locationY>302</locationY>
         <allowBack>false</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -195,6 +297,14 @@
         </connector>
     </start>
     <status>Active</status>
+    <variables>
+        <name>EditedRows</name>
+        <dataType>SObject</dataType>
+        <isCollection>true</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <objectType>Contact</objectType>
+    </variables>
     <variables>
         <name>EditedRowsCount</name>
         <dataType>Number</dataType>

--- a/utils-recipes/main/default/flows/SOQL_Datatable_Show_Selection_in_Collection_Datatable.flow-meta.xml
+++ b/utils-recipes/main/default/flows/SOQL_Datatable_Show_Selection_in_Collection_Datatable.flow-meta.xml
@@ -1,11 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <assignments>
+        <name>Set_Count</name>
+        <label>Set Count</label>
+        <locationX>176</locationX>
+        <locationY>400</locationY>
+        <assignmentItems>
+            <assignToReference>SelectedContactsCount</assignToReference>
+            <operator>AssignCount</operator>
+            <value>
+                <elementReference>SelectedContacts</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Has_Selected_Contacts</targetReference>
+        </connector>
+    </assignments>
+    <decisions>
+        <name>Has_Selected_Contacts</name>
+        <label>Has Selected Contacts</label>
+        <locationX>309</locationX>
+        <locationY>403</locationY>
+        <defaultConnector>
+            <targetReference>No_Contacts_Selected</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>False</defaultConnectorLabel>
+        <rules>
+            <name>True</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>SelectedContactsCount</leftValueReference>
+                <operator>GreaterThan</operator>
+                <rightValue>
+                    <numberValue>0.0</numberValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Selected_Contacts_Loop</targetReference>
+            </connector>
+            <label>True</label>
+        </rules>
+    </decisions>
     <interviewLabel>SOQL Datatable - Show Selection in Collection Datatable {!$Flow.CurrentDateTime}</interviewLabel>
     <label>SOQL Datatable - Show Selection in Collection Datatable</label>
+    <loops>
+        <name>Selected_Contacts_Loop</name>
+        <label>Selected Contacts Loop</label>
+        <locationX>458</locationX>
+        <locationY>402</locationY>
+        <collectionReference>SelectedContacts</collectionReference>
+        <iterationOrder>Asc</iterationOrder>
+        <nextValueConnector>
+            <targetReference>Show_Row_Data</targetReference>
+        </nextValueConnector>
+        <noMoreValuesConnector>
+            <targetReference>Confirm_Selected_Contacts</targetReference>
+        </noMoreValuesConnector>
+    </loops>
     <processMetadataValues>
         <name>BuilderType</name>
         <value>
             <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>FREE_FORM_CANVAS</stringValue>
         </value>
     </processMetadataValues>
     <processMetadataValues>
@@ -18,8 +80,8 @@
     <screens>
         <name>Confirm_Selected_Contacts</name>
         <label>Confirm Selected Contacts</label>
-        <locationX>347</locationX>
-        <locationY>197</locationY>
+        <locationX>676</locationX>
+        <locationY>407</locationY>
         <allowBack>false</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -40,11 +102,27 @@
             <inputParameters>
                 <name>shownFields</name>
                 <value>
-                    <stringValue>Name, Email, Account.Name, Account.Type</stringValue>
+                    <stringValue>Name, Email, AccountId, Account.Type</stringValue>
                 </value>
             </inputParameters>
             <isRequired>true</isRequired>
             <storeOutputAutomatically>true</storeOutputAutomatically>
+        </fields>
+        <showFooter>true</showFooter>
+        <showHeader>true</showHeader>
+    </screens>
+    <screens>
+        <name>No_Contacts_Selected</name>
+        <label>No Contacts Selected</label>
+        <locationX>310</locationX>
+        <locationY>564</locationY>
+        <allowBack>true</allowBack>
+        <allowFinish>false</allowFinish>
+        <allowPause>false</allowPause>
+        <fields>
+            <name>No_Contacts_Selected_Message</name>
+            <fieldText>&lt;p style=&quot;text-align: center;&quot;&gt;No Contacts selected, please go back&lt;/p&gt;</fieldText>
+            <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
         <showHeader>true</showHeader>
@@ -58,7 +136,7 @@
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
         <connector>
-            <targetReference>Confirm_Selected_Contacts</targetReference>
+            <targetReference>Set_Count</targetReference>
         </connector>
         <fields>
             <name>Queried_Contacts_Table</name>
@@ -71,7 +149,7 @@
             <inputParameters>
                 <name>queryString</name>
                 <value>
-                    <stringValue>SELECT Name, Email, Account.Name, Account.Type FROM Contact LIMIT 5</stringValue>
+                    <stringValue>SELECT Name, Email, AccountId, Account.Type FROM Contact LIMIT 5</stringValue>
                 </value>
             </inputParameters>
             <inputParameters>
@@ -85,6 +163,25 @@
                 <assignToReference>SelectedContacts</assignToReference>
                 <name>selectedRows</name>
             </outputParameters>
+        </fields>
+        <showFooter>true</showFooter>
+        <showHeader>true</showHeader>
+    </screens>
+    <screens>
+        <name>Show_Row_Data</name>
+        <label>Show Row Data</label>
+        <locationX>460</locationX>
+        <locationY>206</locationY>
+        <allowBack>true</allowBack>
+        <allowFinish>true</allowFinish>
+        <allowPause>false</allowPause>
+        <connector>
+            <targetReference>Selected_Contacts_Loop</targetReference>
+        </connector>
+        <fields>
+            <name>Row_Data_Text</name>
+            <fieldText>&lt;p&gt;Below is Account Info for: {!Selected_Contacts_Loop.Name}&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;Account Name: {!Selected_Contacts_Loop.Account.Name}&lt;/p&gt;&lt;p&gt;Account Type: {!Selected_Contacts_Loop.Account.Type}&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;IMPORTANT&lt;/b&gt;: You must query the field with SOQL so it can be displayed here. &lt;span style=&quot;font-family: courier;&quot;&gt;soqlDatatable&lt;/span&gt; does not automatically pull in fields for display in a flow that is not explicitly queried.&lt;/p&gt;</fieldText>
+            <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
         <showHeader>true</showHeader>
@@ -104,5 +201,16 @@
         <isInput>false</isInput>
         <isOutput>false</isOutput>
         <objectType>Contact</objectType>
+    </variables>
+    <variables>
+        <name>SelectedContactsCount</name>
+        <dataType>Number</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <scale>0</scale>
+        <value>
+            <numberValue>0.0</numberValue>
+        </value>
     </variables>
 </Flow>


### PR DESCRIPTION
1) Fixed issues with `soql`/`collectionDatatable` meta property configs for Screen Flows.
    - This might be a breaking change if you used `collectionDatatable.recordCollection` in any way, it was originally meant as input only and this fixes that.
    - This might be a breaking change if you used `useLoadStyleHackForOverflow` in the past few days, it was originally meant as input only and this fixes that.

2) Moved `useLoadStyleHackForOverflow` from static resource to `renderedCallback` style tag appending.
    - The overflow hack is better scoped now, so it can be used when multiple `soql`/`collectionDatatables` are on the same page.