### PR TITLE
Added object icon to soqlDatatable

### DIFF
--- a/utils-core/main/default/lwc/baseDatatable/baseDatatable.html
+++ b/utils-core/main/default/lwc/baseDatatable/baseDatatable.html
@@ -35,7 +35,7 @@
 <template>
   <c-message-service boundary={uniqueBoundary}></c-message-service>
 
-  <lightning-card>
+  <lightning-card icon-name={iconName}>
     <div slot="title">
       <slot name="title">
         <template if:true={showRecordCount}> {title} {recordCountDisplay} </template>

--- a/utils-core/main/default/lwc/baseDatatable/baseDatatable.js
+++ b/utils-core/main/default/lwc/baseDatatable/baseDatatable.js
@@ -76,6 +76,7 @@ export default class BaseDatatable extends LightningElement {
     this._keyField = value;
   }
   @api title;
+  @api iconName;
   @api showRecordCount = false;
 
   // MessageService boundary, for when multiple instances are on same page

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.html
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.html
@@ -39,6 +39,7 @@
     unique-boundary={uniqueBoundary}
     is-save-to-server
     key-field="Id"
+    icon-name={iconName}
     title={title}
     record-id={recordId}
     show-record-count={showRecordCount}

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
@@ -77,6 +77,7 @@ export default class SoqlDatatable extends LightningElement {
 
   @api isRecordBind = false;
   @api title;
+  @api iconName;
   @api showRecordCount = false;
   @api showSearch = false;
   @api showRefreshButton = false;
@@ -169,7 +170,16 @@ export default class SoqlDatatable extends LightningElement {
       this._notifySingleError('getObjectInfo error', error);
     } else if (data) {
       this._objectInfo = data;
-      //console.log(this._objectInfo);
+
+      // Salesforce already returns the object icon URL in objectInfo, but lwc needs it in a different format, so parse the URL
+      // Example: objectInfo returns 'https://fun-momentum-3772-dev-ed.cs43.my.salesforce.com/img/icon/t4v35/standard/account_120.png';
+      //          but lightning-card expects the icon to be specified as 'standard:account'
+      let iconUrlFragments = this._objectInfo.themeInfo.iconUrl.split('/');
+      let iconType = iconUrlFragments[iconUrlFragments.length - 2];
+      let icon = iconUrlFragments[iconUrlFragments.length - 1].replace('_120.png', '');
+      if (!this.iconName) {
+        this.iconName = iconType + ':' + icon;
+      }
 
       // For cleaning columns on output
       this._objectFieldsMap = new Map(Object.entries(this._objectInfo.fields));

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
@@ -171,13 +171,13 @@ export default class SoqlDatatable extends LightningElement {
     } else if (data) {
       this._objectInfo = data;
 
-      // Salesforce already returns the object icon URL in objectInfo, but lwc needs it in a different format, so parse the URL
-      // Example: objectInfo returns 'https://fun-momentum-3772-dev-ed.cs43.my.salesforce.com/img/icon/t4v35/standard/account_120.png';
-      //          but lightning-card expects the icon to be specified as 'standard:account'
-      let iconUrlFragments = this._objectInfo.themeInfo.iconUrl.split('/');
-      let iconType = iconUrlFragments[iconUrlFragments.length - 2];
-      let icon = iconUrlFragments[iconUrlFragments.length - 1].replace('_120.png', '');
       if (!this.iconName) {
+        // Salesforce already returns the object icon URL in objectInfo, but lwc needs it in a different format, so parse the URL
+        // Example: objectInfo returns 'https://fun-momentum-3772-dev-ed.cs43.my.salesforce.com/img/icon/t4v35/standard/account_120.png';
+        //          but lightning-card expects the icon to be specified as 'standard:account'
+        let iconUrlFragments = this._objectInfo.themeInfo.iconUrl.split('/');
+        let iconType = iconUrlFragments[iconUrlFragments.length - 2];
+        let icon = iconUrlFragments[iconUrlFragments.length - 1].replace('_120.png', '');
         this.iconName = iconType + ':' + icon;
       }
 

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js
@@ -172,13 +172,7 @@ export default class SoqlDatatable extends LightningElement {
       this._objectInfo = data;
 
       if (!this.iconName) {
-        // Salesforce already returns the object icon URL in objectInfo, but lwc needs it in a different format, so parse the URL
-        // Example: objectInfo returns 'https://fun-momentum-3772-dev-ed.cs43.my.salesforce.com/img/icon/t4v35/standard/account_120.png';
-        //          but lightning-card expects the icon to be specified as 'standard:account'
-        let iconUrlFragments = this._objectInfo.themeInfo.iconUrl.split('/');
-        let iconType = iconUrlFragments[iconUrlFragments.length - 2];
-        let icon = iconUrlFragments[iconUrlFragments.length - 1].replace('_120.png', '');
-        this.iconName = iconType + ':' + icon;
+        this.iconName = this._extractCardIconNameFromObjectInfo(); // outputs 'standard:account'
       }
 
       // For cleaning columns on output
@@ -360,6 +354,16 @@ export default class SoqlDatatable extends LightningElement {
   }
 
   // Private functions
+
+  _extractCardIconNameFromObjectInfo() {
+    // objectInfo iconUrl example: 'https://fun-momentum-3772-dev-ed.cs43.my.salesforce.com/img/icon/t4v35/standard/account_120.png';
+    if (this._objectInfo.themeInfo.iconUrl) {
+      let iconUrlFragments = this._objectInfo.themeInfo.iconUrl.split('/');
+      let iconType = iconUrlFragments[iconUrlFragments.length - 2]; // outputs 'standard'
+      let icon = iconUrlFragments[iconUrlFragments.length - 1].replace('_120.png', ''); // outputs 'account'
+      this.iconName = iconType + ':' + icon;
+    }
+  }
 
   _getCleanRow(row) {
     for (let fieldName in row) {

--- a/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js-meta.xml
+++ b/utils-core/main/default/lwc/soqlDatatable/soqlDatatable.js-meta.xml
@@ -13,6 +13,7 @@
   <targetConfigs>
     <targetConfig targets="lightning__AppPage, lightning__HomePage">
       <property name="title" label="Title" type="String"/>
+      <property name="iconName" label="Icon" type="String"/>
       <property name="showRecordCount" label="Show Record Count" type="Boolean" default="false"/>
       <property name="showSearch" label="Show Search" type="Boolean" default="false"/>
       <property name="showRefreshButton" label="Show Refresh" type="Boolean" default="false"/>
@@ -32,6 +33,7 @@
     <targetConfig targets="lightning__RecordPage">
       <property name="isRecordBind" label="Enable $CurrentRecord API" type="Boolean" description="Allows merge of current record field values directly to SOQL. User must have FLS access." default="true"/>
       <property name="title" label="Title" type="String"/>
+      <property name="iconName" label="Icon" type="String"/>
       <property name="showRecordCount" label="Show Record Count" type="Boolean" default="false"/>
       <property name="showSearch" label="Show Search" type="Boolean" default="false"/>
       <property name="showRefreshButton" label="Show Refresh" type="Boolean" default="false"/>
@@ -52,6 +54,7 @@
       <propertyType name="sObj" extends="SObject" label="Object"/>
       <property name="recordId" label="Record Id" description="Must be a 15 or 18 digit SObject Id. Allows use of $recordId in your SOQL to merge to this value." type="String" role="inputOnly"/>
       <property name="title" label="Title" type="String" role="inputOnly"/>
+      <property name="iconName" label="Icon" type="String" role="inputOnly"/>
       <property name="showRecordCount" label="Show Record Count" type="Boolean" role="inputOnly" default="false"/>
       <property name="showSearch" label="Show Search" type="Boolean" default="false"/>
       <property name="queryString" label="SOQL String" type="String" default="SELECT ... FROM ..." description="Use $recordId in your SOQL to bind to the Record Id given. Alternatively, use a String Formula to merge flow variables to create Dynamic SOQL. $CurrentRecord API is not supported in Screen Flows." required="true" role="inputOnly"/>


### PR DESCRIPTION
@tsalb I made a few changes to `baseDatatable` and `soqlDatable` to address #97 - it's a fairly small set of changes (with 1 slightly goofy section of javascript code), I'm happy to make any suggestions you have.

The icon can optionally be set via App Builder so that admins can specify a particular icon. When no icon is specified, `soqlDatatable` automatically gets the object's icon from `lightning/uiObjectInfoApi`

- End result of the icon on a table (this screenshot is showing the Contact's standard icon)

   ![image](https://user-images.githubusercontent.com/1267157/123180676-948a0200-d440-11eb-97c5-a8d4f3828e5a.png)

- Optionally specifying an icon in App Builder

  ![image](https://user-images.githubusercontent.com/1267157/123180577-660c2700-d440-11eb-96ef-500cacdcbd9a.png)