### PR TITLE
Add 'identifier' tag to flexipages (Winter'22)

### DIFF
--- a/utils-recipes/main/default/flexipages/Account_Record_Page.flexipage-meta.xml
+++ b/utils-recipes/main/default/flexipages/Account_Record_Page.flexipage-meta.xml
@@ -19,6 +19,7 @@
                     <name>numVisibleActions</name>
                     <value>3</value>
                 </componentInstanceProperties>
+                <identifier>force_highlightsPanel1</identifier>
                 <componentName>force:highlightsPanel</componentName>
             </componentInstance>
         </itemInstances>
@@ -37,6 +38,7 @@
                     <name>richTextValue</name>
                     <value>&lt;p style=&quot;text-align: center;&quot;&gt;The below tables are all powered by &lt;span style=&quot;font-family: courier;&quot;&gt;soqlDatatable&lt;/span&gt;. The actual App Builder &lt;span style=&quot;font-family: courier;&quot;&gt;SOQL String&lt;/span&gt; configuration is shown right above.&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;br&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;Inline Editing is enabled for all tables below!&lt;/p&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexiPage_richText1</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>
@@ -50,6 +52,7 @@
                     <name>richTextValue</name>
                     <value>&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;SELECT Name, Email, MailingState, Account.BillingState &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;FROM Contact &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;WHERE AccountId = $recordId &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;AND MailingState = $CurrentRecord.BillingState&lt;/span&gt;&lt;/p&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_richText2</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>
@@ -98,6 +101,7 @@
                     <name>useRelativeMaxHeight</name>
                     <value>false</value>
                 </componentInstanceProperties>
+                <identifier>soqlDatatable1</identifier>
                 <componentName>soqlDatatable</componentName>
             </componentInstance>
         </itemInstances>
@@ -111,6 +115,7 @@
                     <name>richTextValue</name>
                     <value>&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;SELECT Name, Email, Title, Phone, MailingState&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;FROM Contact &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;WHERE AccountId = $recordId&lt;/span&gt;&lt;/p&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_richText3</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>
@@ -160,6 +165,7 @@
                     <name>useRelativeMaxHeight</name>
                     <value>false</value>
                 </componentInstanceProperties>
+                <identifier>soqlDatatable2</identifier>
                 <componentName>soqlDatatable</componentName>
             </componentInstance>
         </itemInstances>
@@ -173,6 +179,7 @@
                     <name>richTextValue</name>
                     <value>&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;SELECT Name, Type, Industry,&lt;/span&gt;&lt;span style=&quot;font-family: courier; color: rgb(107, 109, 112);&quot;&gt; &lt;/span&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;Website &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;FROM Account &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;WHERE OwnerId = $CurrentRecord.OwnerId&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;AND Id != $recordId&lt;/span&gt;&lt;/p&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_richText4</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>
@@ -218,6 +225,7 @@
                     <name>useRelativeMaxHeight</name>
                     <value>false</value>
                 </componentInstanceProperties>
+                <identifier>soqlDatatable3</identifier>
                 <componentName>soqlDatatable</componentName>
             </componentInstance>
         </itemInstances>
@@ -231,6 +239,7 @@
                     <name>richTextValue</name>
                     <value>&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;SELECT Name, Type, Website, Industry &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;FROM Account &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;WHERE Industry = $CurrentRecord.Industry &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;AND Id != $recordId&lt;/span&gt;&lt;/p&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_richText5</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>
@@ -276,6 +285,7 @@
                     <name>useRelativeMaxHeight</name>
                     <value>false</value>
                 </componentInstanceProperties>
+                <identifier>soqlDatatable4</identifier>
                 <componentName>soqlDatatable</componentName>
             </componentInstance>
         </itemInstances>
@@ -285,6 +295,7 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <identifier>recordPagePublisher1</identifier>
                 <componentName>recordPagePublisher</componentName>
             </componentInstance>
         </itemInstances>
@@ -294,6 +305,7 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <identifier>recordPageSubscriber1</identifier>
                 <componentName>recordPageSubscriber</componentName>
             </componentInstance>
         </itemInstances>
@@ -315,6 +327,7 @@
                     <name>title</name>
                     <value>SOQL Datatables</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_tab1</identifier>
                 <componentName>flexipage:tab</componentName>
             </componentInstance>
         </itemInstances>
@@ -328,6 +341,7 @@
                     <name>title</name>
                     <value>MessageService Publish</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_tab2</identifier>
                 <componentName>flexipage:tab</componentName>
             </componentInstance>
         </itemInstances>
@@ -341,6 +355,7 @@
                     <name>title</name>
                     <value>MessageService Sub</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_tab3</identifier>
                 <componentName>flexipage:tab</componentName>
             </componentInstance>
         </itemInstances>
@@ -354,6 +369,7 @@
                     <name>tabs</name>
                     <value>Facet-08499d5d-be1a-491f-860b-b89791c7d41f</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_tabset1</identifier>
                 <componentName>flexipage:tabset</componentName>
             </componentInstance>
         </itemInstances>
@@ -364,6 +380,7 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <identifier>flexipage_detailPanel1</identifier>
                 <componentName>force:detailPanel</componentName>
             </componentInstance>
         </itemInstances>
@@ -377,6 +394,7 @@
                     <name>hideHeader</name>
                     <value>true</value>
                 </componentInstanceProperties>
+                <identifier>force_relatedListQuickLinksContainer1</identifier>
                 <componentName>force:relatedListQuickLinksContainer</componentName>
             </componentInstance>
         </itemInstances>
@@ -394,6 +412,7 @@
                     <name>title</name>
                     <value>Standard.Tab.detail</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_tab4</identifier>
                 <componentName>flexipage:tab</componentName>
             </componentInstance>
         </itemInstances>
@@ -407,6 +426,7 @@
                     <name>title</name>
                     <value>Standard.Tab.relatedLists</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_tab5</identifier>
                 <componentName>flexipage:tab</componentName>
             </componentInstance>
         </itemInstances>
@@ -424,6 +444,7 @@
                     <name>richTextValue</name>
                     <value>&lt;p style=&quot;text-align: center;&quot;&gt;&lt;b&gt;MessageServiceHandler&lt;/b&gt; is below to handle messageService events. &lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;br&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;This one is using &lt;b&gt;$recordId&lt;/b&gt; as its boundary.&lt;/p&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_richText6</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>
@@ -433,6 +454,7 @@
                     <name>customBoundary</name>
                     <value>$recordId</value>
                 </componentInstanceProperties>
+                <identifier>MessageServiceHandler1</identifier>
                 <componentName>MessageServiceHandler</componentName>
             </componentInstance>
         </itemInstances>
@@ -442,6 +464,7 @@
                     <name>tabs</name>
                     <value>Facet-9bfb73b2-f758-4cb3-b5c6-43cceb067723</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_tabset2</identifier>
                 <componentName>flexipage:tabset</componentName>
             </componentInstance>
         </itemInstances>

--- a/utils-recipes/main/default/flexipages/Aggregate_SOQL_Datatable.flexipage-meta.xml
+++ b/utils-recipes/main/default/flexipages/Aggregate_SOQL_Datatable.flexipage-meta.xml
@@ -38,6 +38,7 @@
                     <name>useRelativeMaxHeight</name>
                     <value>false</value>
                 </componentInstanceProperties>
+                <identifier>soqlDatatable1</identifier>
                 <componentName>soqlDatatable</componentName>
             </componentInstance>
         </itemInstances>
@@ -51,6 +52,7 @@
                     <name>richTextValue</name>
                     <value>&lt;p style=&quot;text-align: center;&quot;&gt;The above table uses the following SOQL string&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;br&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;SELECT COUNT(Id) FROM Account&lt;/p&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexiPage_richText1</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>
@@ -94,6 +96,7 @@
                     <name>useRelativeMaxHeight</name>
                     <value>false</value>
                 </componentInstanceProperties>
+                <identifier>soqlDatatable2</identifier>
                 <componentName>soqlDatatable</componentName>
             </componentInstance>
         </itemInstances>
@@ -107,6 +110,7 @@
                     <name>richTextValue</name>
                     <value>&lt;p style=&quot;text-align: center;&quot;&gt;The above table uses the following SOQL string&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;br&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;span style=&quot;font-family: courier;&quot;&gt;SELECT SUM(ExpectedRevenue) Max_Revenue, FISCAL_YEAR(CloseDate) Close_Date_Year, FISCAL_MONTH(CloseDate) Close_Date_Month FROM Opportunity GROUP BY CloseDate&lt;/span&gt;&lt;/p&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexiPage_richText2</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>

--- a/utils-recipes/main/default/flexipages/Collection_Datatable.flexipage-meta.xml
+++ b/utils-recipes/main/default/flexipages/Collection_Datatable.flexipage-meta.xml
@@ -12,6 +12,7 @@
                     <value>Collection_Datatable_Manipulate_a_Record_Collection</value>
                 </componentInstanceProperties>
                 <componentName>flowruntime:interview</componentName>
+                <identifier>flowruntime_interview1</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -22,9 +23,10 @@
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>richTextValue</name>
-                    <value>&lt;p style=&quot;text-align: center;&quot;&gt;The above Collection Datatable is now using the Allow Overflow (EXPERIMENTAL) boolean to allow for in-line edit lookup to overflow outside its container.&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;br&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;This causes some minor CSS issues but is the only way to get interactive in-line edit menus to show up nicely when there are only a few rows!&lt;/p&gt;</value>
+                    <value>&lt;p style=&quot;text-align: center;&quot;&gt;The above Collection Datatable is now using the Allow Overflow (EXPERIMENTAL) boolean to allow for in-line edit lookup to overflow outside its container.&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;br&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;This causes some minor CSS issues but is the only way to get interactive in-line edit menus to show up nicely when there are only a few rows!&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:richText</componentName>
+                <identifier>flexipage_richText1</identifier>
             </componentInstance>
         </itemInstances>
         <name>region1</name>
@@ -42,6 +44,7 @@
                     <value>SOQL_Datatable_Show_Selection_in_Collection_Datatable</value>
                 </componentInstanceProperties>
                 <componentName>flowruntime:interview</componentName>
+                <identifier>flowruntime_interview2</identifier>
             </componentInstance>
         </itemInstances>
         <name>region2</name>
@@ -59,6 +62,7 @@
                     <value>SOQL_Datatable_With_Flow_Inputs_and_Collection_Datatable</value>
                 </componentInstanceProperties>
                 <componentName>flowruntime:interview</componentName>
+                <identifier>flowruntime_interview3</identifier>
             </componentInstance>
         </itemInstances>
         <name>region3</name>

--- a/utils-recipes/main/default/flexipages/LWC_Utils_Console_Home.flexipage-meta.xml
+++ b/utils-recipes/main/default/flexipages/LWC_Utils_Console_Home.flexipage-meta.xml
@@ -11,6 +11,7 @@
                     <name>richTextValue</name>
                     <value>&lt;p style=&quot;text-align: center;&quot;&gt;Message Service Handler is placed here on the Home Page.&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;br&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;It is also placed on each Record Flexipage that is opened by the tab controls here.&lt;/p&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_richText1</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>
@@ -20,11 +21,13 @@
                     <name>customBoundary</name>
                     <value>workspace_api_example</value>
                 </componentInstanceProperties>
+                <identifier>MessageServiceHandler1</identifier>
                 <componentName>MessageServiceHandler</componentName>
             </componentInstance>
         </itemInstances>
         <itemInstances>
             <componentInstance>
+              <identifier>workspaceApiExamples1</identifier>
                 <componentName>workspaceApiExamples</componentName>
             </componentInstance>
         </itemInstances>

--- a/utils-recipes/main/default/flexipages/LWC_Utils_UtilityBar.flexipage-meta.xml
+++ b/utils-recipes/main/default/flexipages/LWC_Utils_UtilityBar.flexipage-meta.xml
@@ -32,6 +32,7 @@
                     <type>decorator</type>
                     <value>1</value>
                 </componentInstanceProperties>
+                <identifier>MessageServiceHandler1</identifier>
                 <componentName>MessageServiceHandler</componentName>
             </componentInstance>
         </itemInstances>

--- a/utils-recipes/main/default/flexipages/SOQL_Datatable.flexipage-meta.xml
+++ b/utils-recipes/main/default/flexipages/SOQL_Datatable.flexipage-meta.xml
@@ -58,6 +58,7 @@
                     <name>useRelativeMaxHeight</name>
                     <value>true</value>
                 </componentInstanceProperties>
+                <identifier>soqlDatatable1</identifier>
                 <componentName>soqlDatatable</componentName>
             </componentInstance>
         </itemInstances>
@@ -75,6 +76,7 @@
                     <name>richTextValue</name>
                     <value>&lt;p style=&quot;text-align: center;&quot;&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;The &lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: courier;&quot;&gt;SOQL Datatable &lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;to the left is created from the App Builder properties:&lt;/span&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;br&gt;&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;b style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;Title&lt;/b&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;:&lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: courier;&quot;&gt; &apos;Queried Contacts&apos;&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;b style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;Show Record Count&lt;/b&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;:&lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: courier;&quot;&gt; &lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: Roboto, &amp;quot;Open Sans&amp;quot;, sans-serif; background-color: rgb(249, 249, 249);&quot;&gt;☑&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;b style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;Show Refresh&lt;/b&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;:&lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: courier;&quot;&gt; &lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: Roboto, &amp;quot;Open Sans&amp;quot;, sans-serif; background-color: rgb(249, 249, 249);&quot;&gt;☑&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;b style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;SOQL String&lt;/b&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;:&lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: courier;&quot;&gt; &apos;SELECT Id, Name, Email, Phone, LeadSource, AccountId, Account.Type FROM Contact LIMIT 50&apos;&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;b style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;Checkbox Type&lt;/b&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;:&lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: courier;&quot;&gt; &apos;Multi&apos;&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;b style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;Editable Fields&lt;/b&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;:&lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: courier;&quot;&gt; &apos;Name, Email, Phone, LeadSource, AccountId&apos;&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;b style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;Sortable Fields&lt;/b&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;:&lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: courier;&quot;&gt; &apos;Name, Email, Phone, LeadSource, AccountId, Account_Type&apos;&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;b style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;Default Sort Field&lt;/b&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;:&lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: courier;&quot;&gt; &apos;Name&apos;&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;b style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;Default Sort Direction&lt;/b&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;:&lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: courier;&quot;&gt; &apos;asc&apos;&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;b style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;Action Configuration: &apos;&lt;/b&gt;&lt;span style=&quot;color: rgb(0, 0, 0); font-family: courier; font-size: 11px;&quot;&gt;LWC_Utils_SOQL_Datatable_tab&lt;/span&gt;&lt;span style=&quot;color: rgb(0, 0, 0);&quot;&gt;&apos;&lt;/span&gt;&lt;/li&gt;&lt;/ul&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_richText1</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>
@@ -88,11 +90,13 @@
                     <name>richTextValue</name>
                     <value>&lt;p style=&quot;text-align: center;&quot;&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0); font-family: courier;&quot;&gt;SOQL Datatable &lt;/span&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;can use the $CurrentRecord and $recordId API (on record flexipage)&lt;/span&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-size: 10px; font-family: courier; color: rgb(0, 0, 0);&quot;&gt;SELECT Id, Name, Email, Pho&lt;/span&gt;&lt;span style=&quot;font-size: 11px; font-family: courier; color: rgb(0, 0, 0);&quot;&gt;﻿&lt;/span&gt;&lt;span style=&quot;font-size: 10px; font-family: courier; color: rgb(0, 0, 0);&quot;&gt;ne &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-size: 10px; font-family: courier; color: rgb(0, 0, 0);&quot;&gt;FROM Contact &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-size: 10px; font-family: courier; color: rgb(0, 0, 0);&quot;&gt;WHERE AccountId = $recordId&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-size: 10px; font-family: courier; color: rgb(0, 0, 0);&quot;&gt;AND Account.MailingState = $CurrentRecord.MailingState&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;span style=&quot;font-size: 11px; color: rgb(0, 0, 0);&quot;&gt;Click the button below to see&lt;/span&gt;&lt;/p&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexiPage_richText2</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <identifier>soqlDatatableNavigationExample1</identifier>
                 <componentName>soqlDatatableNavigationExample</componentName>
             </componentInstance>
         </itemInstances>
@@ -110,11 +114,13 @@
                     <name>richTextValue</name>
                     <value>&lt;p style=&quot;text-align: center;&quot;&gt;&lt;span style=&quot;color: rgb(0, 0, 0); font-size: 11px;&quot;&gt;It&apos;s also possible to use this component directly from an LWC.&lt;/span&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;color: rgb(0, 0, 0); font-size: 10px; font-family: courier;&quot;&gt;SELECT Title, Name, Email, Account.Name, Account.Type&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;color: rgb(0, 0, 0); font-size: 10px; font-family: courier;&quot;&gt;FROM Contact &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;color: rgb(0, 0, 0); font-size: 10px; font-family: courier;&quot;&gt;LIMIT 5&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p style=&quot;text-align: center;&quot;&gt;&lt;span style=&quot;color: rgb(0, 0, 0); font-size: 11px;&quot;&gt;Click the button below to see&lt;/span&gt;&lt;/p&gt;</value>
                 </componentInstanceProperties>
+                <identifier>flexipage_richText3</identifier>
                 <componentName>flexipage:richText</componentName>
             </componentInstance>
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <identifier>soqlDatatableLauncherExample1</identifier>
                 <componentName>soqlDatatableLauncherExample</componentName>
             </componentInstance>
         </itemInstances>

--- a/utils-recipes/main/default/flexipages/Sample_App_Aura.flexipage-meta.xml
+++ b/utils-recipes/main/default/flexipages/Sample_App_Aura.flexipage-meta.xml
@@ -4,11 +4,13 @@
         <itemInstances>
             <componentInstance>
                 <componentName>AccountSelector</componentName>
+                <identifier>c_AccountSelector1</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
             <componentInstance>
                 <componentName>ContactDatatable</componentName>
+                <identifier>c_ContactDatatable1</identifier>
             </componentInstance>
         </itemInstances>
         <name>region1</name>

--- a/utils-recipes/main/default/flexipages/Sample_App_LWC.flexipage-meta.xml
+++ b/utils-recipes/main/default/flexipages/Sample_App_LWC.flexipage-meta.xml
@@ -4,11 +4,13 @@
         <itemInstances>
             <componentInstance>
                 <componentName>lwcAccountSelector</componentName>
+                <identifier>c_lwcAccountSelector1</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
             <componentInstance>
                 <componentName>lwcContactDatatable</componentName>
+                <identifier>c_lwcContactDatatable1</identifier>
             </componentInstance>
         </itemInstances>
         <name>main</name>


### PR DESCRIPTION
Winter'22 introduced a breaking change where flexipages now need an
'identifier' tag next to 'componentName'. This commit adds this tag to
the flexipages in the recipes.

https://salesforce.stackexchange.com/questions/357206/problem-when-deploying-flexipages-on-winter-22-org-the-xxxx-component-in