### PR TITLE
utils-recipes/ContactDatatableController.js fix

### DIFF
--- a/utils-recipes/main/default/aura/ContactDatatable/ContactDatatableController.js
+++ b/utils-recipes/main/default/aura/ContactDatatable/ContactDatatableController.js
@@ -33,8 +33,9 @@
     }
   },
   handleAccountSelected: function (component, event, helper) {
-    const value = event.getParam('value');
-    helper.loadContactTable(component, value);
+    let value = event.getParam('value');
+    let accountId = (value.accountId)? value.accountId:value;
+    helper.loadContactTable(component, accountId);
   },
   handleClearTable: function (component, event, helper) {
     component.set('v.tableData', null);


### PR DESCRIPTION
On handleAccountSelected: In Aura(AccountSelector) it passes "value" as a string like "0011j000000FLwoEAG"
But in lwcAccountSelector it passed "value" as an json object {accountId: 'xx'}. 
So when you drag them together on the same page. It won't work. This PR will fix it. 
Allow me to drag "Contacts" Aura into Sample App (LWC).